### PR TITLE
Add benchmark infrastructure

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -16,7 +16,6 @@ jmh {
     fork = 1
     warmupIterations = 3
     iterations = 10
-    timeOnIteration = '1s'
     forceGC = true
 
 //    uncomment this if you want to view the stack profiler output (isn't always useful)

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -17,11 +17,9 @@ jmh {
     warmupIterations = 2
     iterations = 5
 
-    benchmarkMode = ['Throughput']
-
     profilers = ['stack']
 
 //    uncomment this if you want the console progress summary written to a file instead
 //    humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
-    resultFormat = "JSON"
+//    resultFormat = "JSON"
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -14,12 +14,16 @@ jmh {
     jmhVersion = "1.18"
 
     fork = 1
-    warmupIterations = 2
-    iterations = 5
+    warmupIterations = 3
+    iterations = 10
+    timeOnIteration = '1s'
+    forceGC = true
 
-    profilers = ['stack']
+//    uncomment this if you want to view the stack profiler output (isn't always useful)
+//    profilers = ['stack']
 
 //    uncomment this if you want the console progress summary written to a file instead
 //    humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
-//    resultFormat = "JSON"
+
+    resultFormat = "JSON"
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id "me.champeau.gradle.jmh" version "0.3.1"
+}
+
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: "me.champeau.gradle.jmh"
+
+dependencies {
+    compile project(':etomica-core')
+}
+
+jmh {
+    jmhVersion = "1.18"
+
+    fork = 1
+    warmupIterations = 2
+    iterations = 5
+
+    benchmarkMode = ['Throughput']
+
+    profilers = ['stack']
+
+//    uncomment this if you want the console progress summary written to a file instead
+//    humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
+    resultFormat = "JSON"
+}

--- a/benchmarks/src/jmh/java/etomica/math/ErfcBenchmark.java
+++ b/benchmarks/src/jmh/java/etomica/math/ErfcBenchmark.java
@@ -1,0 +1,29 @@
+package etomica.math;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by alex on 4/30/17.
+ */
+@State(Scope.Benchmark)
+@Measurement(time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class ErfcBenchmark {
+
+    @Param({"0.0", "0.05", "2.0"})
+    public double x;
+
+    @Benchmark
+    public double etomicaErfc() {
+        return etomica.math.SpecialFunctions.erfc(x);
+    }
+
+    @Benchmark
+    public double apacheErfc() {
+        return org.apache.commons.math3.special.Erf.erfc(x);
+    }
+
+}

--- a/benchmarks/src/jmh/java/etomica/math/FactorialBenchmark.java
+++ b/benchmarks/src/jmh/java/etomica/math/FactorialBenchmark.java
@@ -1,0 +1,27 @@
+package etomica.math;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+
+/**
+ * Created by alex on 4/29/17.
+ */
+@State(Scope.Benchmark)
+public class FactorialBenchmark {
+
+    @Param({"1", "5", "20"})
+    public int n;
+
+    @Benchmark
+    public long benchEtomicaFactorial() {
+        return etomica.math.SpecialFunctions.factorial(n);
+    }
+
+    @Benchmark
+    public long benchApacheFactorial() {
+        return org.apache.commons.math3.util.CombinatoricsUtils.factorial(n);
+    }
+}

--- a/benchmarks/src/jmh/java/etomica/math/FactorialBenchmark.java
+++ b/benchmarks/src/jmh/java/etomica/math/FactorialBenchmark.java
@@ -1,27 +1,29 @@
 package etomica.math;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
 
 
 /**
  * Created by alex on 4/29/17.
  */
 @State(Scope.Benchmark)
+@Measurement(time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class FactorialBenchmark {
 
     @Param({"1", "5", "20"})
     public int n;
 
     @Benchmark
-    public long benchEtomicaFactorial() {
+    public long etomicaFactorial() {
         return etomica.math.SpecialFunctions.factorial(n);
     }
 
     @Benchmark
-    public long benchApacheFactorial() {
+    public long apacheFactorial() {
         return org.apache.commons.math3.util.CombinatoricsUtils.factorial(n);
     }
 }

--- a/benchmarks/src/jmh/java/etomica/math/LnFactorialBenchmark.java
+++ b/benchmarks/src/jmh/java/etomica/math/LnFactorialBenchmark.java
@@ -1,0 +1,28 @@
+package etomica.math;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by alex on 4/30/17.
+ */
+@State(Scope.Benchmark)
+@Measurement(time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class LnFactorialBenchmark {
+
+    @Param({"0", "20", "100", "10000"})
+    public int n;
+
+    @Benchmark
+    public double etomicaLnFactorial() {
+        return etomica.math.SpecialFunctions.lnFactorial(n);
+    }
+
+    @Benchmark
+    public double apacheLnFactorial() {
+        return org.apache.commons.math3.util.CombinatoricsUtils.factorialLog(n);
+    }
+}

--- a/benchmarks/src/jmh/java/etomica/simulation/prototypes/HSMD3DBenchmark.java
+++ b/benchmarks/src/jmh/java/etomica/simulation/prototypes/HSMD3DBenchmark.java
@@ -1,0 +1,34 @@
+package etomica.simulation.prototypes;
+
+import etomica.integrator.Integrator;
+import etomica.integrator.IntegratorMD;
+import etomica.simulation.Simulation;
+import etomica.space3d.Space3D;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Created by alex on 4/29/17.
+ */
+@State(Scope.Benchmark)
+public class HSMD3DBenchmark {
+
+    private Simulation sim;
+
+    @Setup
+    public void setUp() {
+        sim = new HSMD3D(Space3D.getInstance());
+    }
+
+    @Benchmark
+    public void hsmd3d() {
+        sim.getIntegrator().doStep();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,3 +22,5 @@ include 'etomica-apps'
 include 'etomica-modules'
 include 'etomica-graph'
 include 'etomica-graphics3D'
+
+include 'benchmarks'


### PR DESCRIPTION
Adds module and gradle tasks for benchmarks. Some initial example benchmarks.

Uses [JMH](http://openjdk.java.net/projects/code-tools/jmh/). Benchmarks can be run with `./gradlew jmh` (no way to run them from the ide at the moment).