### PR TITLE
Fix varargs warnings

### DIFF
--- a/etomica-apps/src/main/java/etomica/virial/GUI/components/BuilderCollectionPotential.java
+++ b/etomica-apps/src/main/java/etomica/virial/GUI/components/BuilderCollectionPotential.java
@@ -725,7 +725,7 @@ public class BuilderCollectionPotential {
 				if(MethodS1[j].getReturnType().equals(IAtomType.class)){
 					if(MethodS1[j].toString().toUpperCase().contains(Site1.toUpperCase()+"TYPE")|| MethodS1[j].toString().toUpperCase().contains(Site1Name.toUpperCase()+"TYPE")){
 						try {
-							Site1Atom = (IAtomType) MethodS1[j].invoke(species1, null);
+							Site1Atom = (IAtomType) MethodS1[j].invoke(species1);
 							SiteAtoms[0] = Site1Atom;
 						} catch (Exception e) {
 							e.printStackTrace();
@@ -742,7 +742,7 @@ public class BuilderCollectionPotential {
 					if(MethodS2[k].toString().toUpperCase().contains(Site2.toUpperCase()+"TYPE")|| MethodS2[k].toString().toUpperCase().contains(Site2Name.toUpperCase()+"TYPE")){
 						System.out.println(Site2+" "+ MethodS2[k].toString());
 						try {
-							Site2Atom = (IAtomType) MethodS2[k].invoke(species2, null);
+							Site2Atom = (IAtomType) MethodS2[k].invoke(species2);
 							SiteAtoms[1] = Site2Atom;
 						} catch (Exception e) {
 							e.printStackTrace();

--- a/etomica-apps/src/main/java/etomica/virial/GUI/controllers/ControllerSpeciesSelection.java
+++ b/etomica-apps/src/main/java/etomica/virial/GUI/controllers/ControllerSpeciesSelection.java
@@ -231,7 +231,7 @@ public class ControllerSpeciesSelection {
 					if(modelSelectedSpecies.getSpeciesDataModel(modelSpeciesSelection.getNthSpeciesSelectedIndex()).getClass().getName().contains("Alkane")){
 						modelSelectedSpecies.setSpeciesDataModel(modelSelectedSpecies.getSpeciesDataModel(modelSpeciesSelection.getNthSpeciesSelectedIndex()).getClass().getConstructor(Integer.TYPE).newInstance(modelSpeciesSelection.getConstructorObject()),modelSpeciesSelection.getNthSpeciesSelectedIndex()+1);
 					}else{
-						modelSelectedSpecies.setSpeciesDataModel(modelSelectedSpecies.getSpeciesDataModel(modelSpeciesSelection.getNthSpeciesSelectedIndex()).getClass().getDeclaredConstructor().newInstance(null),modelSpeciesSelection.getNthSpeciesSelectedIndex()+1);
+						modelSelectedSpecies.setSpeciesDataModel(modelSelectedSpecies.getSpeciesDataModel(modelSpeciesSelection.getNthSpeciesSelectedIndex()).getClass().getDeclaredConstructor().newInstance(),modelSpeciesSelection.getNthSpeciesSelectedIndex()+1);
 					}
 				} catch (InstantiationException e) {
 					// TODO Auto-generated catch block

--- a/etomica-apps/src/main/java/etomica/virial/GUI/models/ModelSpeciesSelection.java
+++ b/etomica-apps/src/main/java/etomica/virial/GUI/models/ModelSpeciesSelection.java
@@ -286,7 +286,7 @@ public class ModelSpeciesSelection {
         for (int i=0; i<potentialsStringList.length; i++) {
 		   try {
 			   try {
-				   potentialsStringList[i] = (String)potentialList[i].getMethod("getMolecularModelDisplayName", new Class[0]).invoke(potentialList[i].getConstructor().newInstance(new Object[0]),new Object[0]);
+				   potentialsStringList[i] = (String)potentialList[i].getMethod("getMolecularModelDisplayName", new Class[0]).invoke(potentialList[i].getConstructor().newInstance());
 					} 
 			   catch (InstantiationException e1) {
 				   // TODO Auto-generated catch block

--- a/etomica-core/src/main/java/etomica/modifier/ModifierGeneral.java
+++ b/etomica-core/src/main/java/etomica/modifier/ModifierGeneral.java
@@ -102,10 +102,10 @@ public class ModifierGeneral implements Modifier, java.io.Serializable {
                 Class[] argClasses = writeMethod[j].getParameterTypes();
                 // perhaps there's a better way to sniff than Class.getName().equals("int")
                 if (argClasses[0].getName().equals("double")) {
-                    writeMethod[j].invoke(object[j], new Object[] {new Double(d)});
+                    writeMethod[j].invoke(object[j], d);
                 }
                 else if (argClasses[0].getName().equals("int")) {
-                    writeMethod[j].invoke(object[j], new Object[] {new Integer((int)d)});
+                    writeMethod[j].invoke(object[j], (int) d);
                 }
             }
             catch(InvocationTargetException ex) {
@@ -126,10 +126,10 @@ public class ModifierGeneral implements Modifier, java.io.Serializable {
         try {
             Class returnType = readMethod[0].getReturnType();
             if (returnType.getName().equals("double")) {
-                value = (Double)readMethod[0].invoke(object[0], (Object[])null);
+                value = (Double)readMethod[0].invoke(object[0]);
             }
             else if (returnType.getName().equals("int")) {
-                value = (Integer)readMethod[0].invoke(object[0],  (Object[])null);
+                value = (Integer)readMethod[0].invoke(object[0]);
             }
         }
         catch(InvocationTargetException ex) {

--- a/etomica-core/src/main/java/etomica/units/Dimension.java
+++ b/etomica-core/src/main/java/etomica/units/Dimension.java
@@ -116,7 +116,7 @@ public class Dimension implements java.io.Serializable {
             String methodName = methods[i].getMethod().getName();
             if(methodName.equalsIgnoreCase("get"+property+"Dimension")) {
                 try {
-                    return (Dimension)methods[i].getMethod().invoke(obj, (Object[])null);
+                    return (Dimension)methods[i].getMethod().invoke(obj);
                 }
                 catch(java.lang.reflect.InvocationTargetException ex) {
                     System.out.println("InvocationTargetException in Dimension.introspect");

--- a/etomica-core/src/main/java/etomica/units/Lister.java
+++ b/etomica-core/src/main/java/etomica/units/Lister.java
@@ -110,7 +110,7 @@ public final class Lister {
 			Class c = us.getClass();
 			Method[] methodSet = c.getDeclaredMethods();
 			for (int i=0; i<methodSet.length;i++){
-				String s = methodSet[i].invoke(us,(Object[])null).getClass().getName();
+				String s = methodSet[i].invoke(us).getClass().getName();
 				//System.out.println(s);
 				if (unitList.contains(s)){
 					unitsInSystem.add(s);


### PR DESCRIPTION
Can't we just do this? The reflection javadoc says you can use a "varargs array of length 0" for methods with no parameters, which means just not passing any additional parameters.