### PR TITLE
Don't overwrite central atom with neighbor when iterating down site list

### DIFF
--- a/etomica-core/src/main/java/etomica/nbr/site/Api1ASite.java
+++ b/etomica-core/src/main/java/etomica/nbr/site/Api1ASite.java
@@ -75,15 +75,14 @@ public class Api1ASite implements AtomsetIteratorPDT, java.io.Serializable {
                 return null;
             }
             upListNow = false;
+            pair.atom1 = pair.atom0;
             neighborIterator.setDirection(IteratorDirective.Direction.DOWN);
             neighborIterator.reset();
-            pair.atom1 = ((AtomSite)neighborIterator.next()).getAtom();
-            return pair;
         }
         if (!neighborIterator.hasNext()) {
             return null;
         }
-        pair.atom1 = ((AtomSite)neighborIterator.next()).getAtom();
+        pair.atom0 = ((AtomSite)neighborIterator.next()).getAtom();
         return pair;
     }
 

--- a/etomica-core/src/main/java/etomica/nbr/site/Api1ASite.java
+++ b/etomica-core/src/main/java/etomica/nbr/site/Api1ASite.java
@@ -83,7 +83,7 @@ public class Api1ASite implements AtomsetIteratorPDT, java.io.Serializable {
         if (!neighborIterator.hasNext()) {
             return null;
         }
-        pair.atom0 = ((AtomSite)neighborIterator.next()).getAtom();
+        pair.atom1 = ((AtomSite)neighborIterator.next()).getAtom();
         return pair;
     }
 


### PR DESCRIPTION
This could alternatively be fixed by setting atom1 = atom0 before iterating downlist, then putting new neighbors in atom0, as it was doing.  Is there any reason to do it that way (i.e., so that pairs are always in order such that atom0 is downlist from atom1)?