### PR TITLE
Special functions test

### DIFF
--- a/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
+++ b/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
@@ -10,45 +10,56 @@ import etomica.units.Mole;
  * Static-method library of various functions
  */
 public final class SpecialFunctions {
-    
-    private SpecialFunctions() {}
-    
+
+    private static final double lnsqrt2Pi = 0.5 * Math.log(2 * Math.PI);
+    private static final double[] lnGammaCoeff = new double[]{
+            676.5203681218851, -1259.1392167224028,
+            771.32342877765313, -176.61502916214059, 12.507343278686905,
+            -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7};
+    protected static double[] lp = new double[]{1};
+    protected static double lastLPX = 0;
+    protected static int maxLPN = 0;
+
+    private SpecialFunctions() {
+    }
+
     /**
      * Complementary error function, computed using the approximant 7.1.26 of Abramowitz & Stegun.
      * Absolute accuracy to within ~10^-7. If more precision is required,
      * consider using {@link org.apache.commons.math3.special.Erf#erfc}, which is more accurate
      * but substantially slower (~10x - 100x) than the method given here.
-     * @return value of complementary error function.
+     *
      * @param x argument to function, may take values from  Double.NEGATIVE_INFINITY to Double.POSITIVE_INFINITY.
+     * @return value of complementary error function.
      */
     public static double erfc(double x) {
         if (x < 0) {
             return 2 - erfc(-x);
         }
-        double t = 1.0/(1.0 + 0.3275911*x);
+        double t = 1.0 / (1.0 + 0.3275911 * x);
         return (t * (
-                  0.254829592 + t * (
-                     -0.284496736 + t * (
-                       1.421413741 +  t * (
-                         - 1.453152027 + 1.061405429*t)))))*Math.exp(-x*x);
+                0.254829592 + t * (
+                        -0.284496736 + t * (
+                                1.421413741 + t * (
+                                        -1.453152027 + 1.061405429 * t))))) * Math.exp(-x * x);
     }
-    
+
     /**
      * The factorial function, n! Will overflow with any input value greater than 20.
      *
      * @param n an integer greater than or equal to 0
-     * @throws IllegalArgumentException if n < 0
      * @return the factorial of n
+     * @throws IllegalArgumentException if n < 0
      */
-    public static long factorial(int n){
-        if(n < 0){
-            throw new IllegalArgumentException("Argument less than zero: "+n);
+    public static long factorial(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Argument less than zero: " + n);
         }
         if (n < 2) {
             return 1;
         }
         long product = 2;
-        for (int i=3; i<n+1; i++) {
+        for (int i = 3; i < n + 1; i++) {
             product *= i;
         }
         return product;
@@ -58,21 +69,21 @@ public final class SpecialFunctions {
      * The log of the factorial function, ln(n!). Will not overflow even if n! would be large.
      *
      * @param n an integer greater than or equal to 0
-     * @throws IllegalArgumentException if n < 0
      * @return the natural logarithm of the factorial of n.
+     * @throws IllegalArgumentException if n < 0
      */
     public static double lnFactorial(int n) {
-        if(n < 0) {
-            throw new IllegalArgumentException("Argument less than zero: "+n);
+        if (n < 0) {
+            throw new IllegalArgumentException("Argument less than zero: " + n);
         }
         if (n < 2) {
             return 0;
         }
         long p = 1;
         double sum = 0;
-        for (int i=n; i>1; i--) {
+        for (int i = n; i > 1; i--) {
             p *= i;
-            if (p > Integer.MAX_VALUE/(i-1)) {
+            if (p > Integer.MAX_VALUE / (i - 1)) {
                 sum += Math.log(p);
                 p = 1;
             }
@@ -81,207 +92,154 @@ public final class SpecialFunctions {
         return sum;
     }
 
-
     /**
      * Returns the ln(gamma), the natural logarithm of the gamma function.
      * Lanczos approximation, with precision ~15 digits
      * coefficients from GSL (GNU Scientific Library) with g=7
      *
-     * @param x a non-negative number.
+     * @param x a positive number.
      * @return the natural logarithm of the gamma function of x.
+     * @throws IllegalArgumentException if x is not positive.
      */
     public static double lnGamma(double x) {
-        if (x < 0) {
-            throw new IllegalArgumentException("x must not be negative");
-        }
-        if (x == 0) {
-            return Double.POSITIVE_INFINITY;
+        if (x <= 0) {
+            throw new IllegalArgumentException("x must be positive");
         }
         if (x < 0.5) {
-            return Math.log(Math.PI / (Math.sin(Math.PI*x))) - lnGamma(1-x);
+            return Math.log(Math.PI / (Math.sin(Math.PI * x))) - lnGamma(1 - x);
         }
         double tmp = x + 7 - 0.5;
         double ser = 0.99999999999980993;
-        for(int i=7; i>-1; i--) {
-            ser += lnGammaCoeff[i]/(x+i);
+        for (int i = 7; i > -1; i--) {
+            ser += lnGammaCoeff[i] / (x + i);
         }
-        double y = lnsqrt2Pi + (x-0.5)*Math.log(tmp) - tmp + Math.log(ser); 
+        double y = lnsqrt2Pi + (x - 0.5) * Math.log(tmp) - tmp + Math.log(ser);
         return y;
     }
-    private static final double lnsqrt2Pi = 0.5*Math.log(2*Math.PI);
-    private static final double[] lnGammaCoeff = new double[] {
-                                 676.5203681218851, -1259.1392167224028,
-            771.32342877765313, -176.61502916214059, 12.507343278686905,
-            -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7};
 
+    /**
+     * Returns the value of the gamma function of x.
+     *
+     * @param x a positive number.
+     * @return the gamma function of x.
+     * @throws IllegalArgumentException if x is not positive.
+     */
     public static double gamma(double x) {
-        if (x == 0) {
-            return 1;
+        if (x <= 0) {
+            throw new IllegalArgumentException("x must be positive");
         }
         if (x < 0.5) {
-            return Math.PI / (Math.sin(Math.PI*x)*gamma(1-x));
+            return Math.PI / (Math.sin(Math.PI * x) * gamma(1 - x));
         }
-        double y = Math.exp(lnGamma(x)); 
-        return y;
-    }
-    
-    /**
-     * Normalized incomplete gamma function, equal to
-     * Integrate[Exp[-t] t^(a-1),{t,x,Infinity}]/Gamma[a]
-     */
-    //method is not tested
-    public static double gammaQ(double a, double x) {
-    	if(x < 0.0 || a < 0.0) throw new IllegalArgumentException();
-    	if(a == 0.0) return 1.0;
-    	if(x < a+1.0) {
-    		return 1.0 - gser(a, x);
-    	}
-    	return gcf(a, x);
-    }
-    
-    private static double gser(double a, double x) {
-    	int nmax = 500;
-    	double epsilon = 3.0e-12;
-    	double ap = a;
-    	double sum = 1.0/a;
-    	double del = sum;
-    	for(int n=1; n<=nmax; n++) {
-    		ap++;
-    		del *= x/ap;
-    		sum += del;
-    		if(Math.abs(del) < Math.abs(sum)*epsilon) break;
-    	}
-    	return sum * Math.exp(-x + a*Math.log(x) - lnGamma(a));
-    }
-    
-    private static double gcf(double a, double x) {
-        int imax = 500;
-        double epsilon = 3.0e-12;
-        double b = x + 1.0 - a;
-        double c = 1.0 / Double.MIN_VALUE;
-        double d = 1.0 / b;
-        double h = d;
-        for (int i = 0; i <= imax; i++) {
-            double an = -i * (i - a);
-            b += 2.0;
-            d = an * d + b;
-            if (Math.abs(d) < Double.MIN_VALUE)
-                d = Double.MIN_VALUE;
-            c = b + an / c;
-            if (Math.abs(c) < Double.MIN_VALUE)
-                c = Double.MIN_VALUE;
-            d = 1.0 / d;
-            double del = d * c;
-            h *= del;
-            if (Math.abs(del - 1.0) < epsilon)
-                break;
-        }
-        return Math.exp(-x + a * Math.log(x) - lnGamma(a)) * h;
+        return Math.exp(lnGamma(x));
     }
 
     /**
-     * The confluent hypergeometric function, usually given the symbol 1F1.  This is a porting to Java
-     * of the function hyperg_1F1_luke in the file specfunc/hyperg_1F1.c from the GNU Scientific Library.
-     * For algorithm, see [Luke, Algorithms for the Computation of Mathematical Functions, p.182]
-     * (GSL license info to be added) GSL home page is http://www.gnu.org/software/gsl/
+     * The confluent hypergeometric function, usually given the symbol 1F1.
+     * For information about the function and use of parameters consult the link:
+     * http://mathworld.wolfram.com/ConfluentHypergeometricFunctionoftheFirstKind.html
      */
     public static double confluentHypergeometric1F1(double a, double c, double xin) {
-    	/*
-    	takes in the numerator parameter of 1F1 (ap), the denominator parameter of 1F1 (cp) and the value of the arguement (z)&
-    	returns either the value of the rational approximation of 1F1 when it converges to a given tolerance or,if that given 
+        /*
+        takes in the numerator parameter of 1F1 (ap), the denominator parameter of 1F1 (cp) and the value of the argument (z)&
+    	returns either the value of the rational approximation of 1F1 when it converges to a given tolerance or,if that given
     	tolerance is not met, will ask for different values of ap, cp & z.
-    	Also: A and B	will contain the values of the numerator and denominator polynomials, respectively, for all degrees 
+    	Also: A and B	will contain the values of the numerator and denominator polynomials, respectively, for all degrees
     	from 0 to n inclusive where n is the maximum degree for which the values of the polynomials are to be calculated
     	*/
 
 
-    	double x = -xin;
-    	double [] arrayA = new double [101]; //the numerator of the rational approx.
-    	double [] arrayB = new double [101]; //the denominator of the rational approx.
-    	double [] arrayR = new double [101]; //the value of the rational aproximations.
-    	double [] arrayD = new double [101]; //difference in subsequent rational approx.
-    	int n = 100; //number of iterations,if you change this number must also change condition of the last if statement
-    	int n1 = n+1; 
-    	double tolerance = 1E-15;//specified tolerance
+        double x = -xin;
+        double[] arrayA = new double[101]; //the numerator of the rational approx.
+        double[] arrayB = new double[101]; //the denominator of the rational approx.
+        double[] arrayR = new double[101]; //the value of the rational approximations.
+        double[] arrayD = new double[101]; //difference in subsequent rational approx.
+        int n = 100; //number of iterations,if you change this number must also change condition of the last if statement
+        int n1 = n + 1;
+        double tolerance = 1E-15;//specified tolerance
 
-    	double zero = 0.0;
-    	double one = 1.0;
-    	double two = 2.0;
-    	double three = 3.0;
+        double zero = 0.0;
+        double one = 1.0;
+        double two = 2.0;
+        double three = 3.0;
 
 
-    	// to understand the following code refer to rational approximation of 1F1(ap; cp; -z)
+        // to understand the following code refer to rational approximation of 1F1(ap; cp; -z)
 
-    	double ct1 = a*x/c;
-    	double xn3 = zero;
-    	double xn1 = two;
-    	double z2 = x/two;
-    	double ct2 = z2/(one+c);
-    	double xn2 = one;
+        double ct1 = a * x / c;
+        double xn3 = zero;
+        double xn1 = two;
+        double z2 = x / two;
+        double ct2 = z2 / (one + c);
+        double xn2 = one;
 
-    	arrayA[0] = one;
-    	arrayB[0] = one;
-    	arrayB[1] = one+(one+a)*z2/c;
-    	arrayA[1] = arrayB[1]-ct1;
-    	arrayB[2] = one+(two+arrayB[1])*(two+a)/three*ct2;
-    	arrayA[2] = arrayB[2]-(one+ct2)*ct1;
-    	ct1 = three;
-    	double xn0 = three;
-    	//for i=3,...,n the values of arrayA[1+i] and arrayB[1+i] are calculated using the recurrence relations below*/
+        arrayA[0] = one;
+        arrayB[0] = one;
+        arrayB[1] = one + (one + a) * z2 / c;
+        arrayA[1] = arrayB[1] - ct1;
+        arrayB[2] = one + (two + arrayB[1]) * (two + a) / three * ct2;
+        arrayA[2] = arrayB[2] - (one + ct2) * ct1;
+        ct1 = three;
+        double xn0 = three;
+        //for i=3,...,n the values of arrayA[1+i] and arrayB[1+i] are calculated using the recurrence relations below*/
 
-    	for (int i=3; i<=n; i++){
-    		//calculation of the multipliers for the recursion
-    		ct2 = z2/ct1/(c+xn1);
-    		double g1 = one + ct2*(xn2-a);
-    		ct2 = ct2*(a+xn1)/(c+xn2);
-    		double g2 = ct2*((c-xn1)+(a+xn0)/(ct1+two)*z2);
-    		double g3 = ct2*z2*z2/ct1/(ct1-two)*(a+xn2)/(c+xn3)*(a-xn2);
+        for (int i = 3; i <= n; i++) {
+            //calculation of the multipliers for the recursion
+            ct2 = z2 / ct1 / (c + xn1);
+            double g1 = one + ct2 * (xn2 - a);
+            ct2 = ct2 * (a + xn1) / (c + xn2);
+            double g2 = ct2 * ((c - xn1) + (a + xn0) / (ct1 + two) * z2);
+            double g3 = ct2 * z2 * z2 / ct1 / (ct1 - two) * (a + xn2) / (c + xn3) * (a - xn2);
 
-    		//the recurrance relations for arrayA[i+1] and arrayB[i+1] are as follows
+            //the recurrance relations for arrayA[i+1] and arrayB[i+1] are as follows
 
-    		arrayB[i] = g1*arrayB[i-1] + g2*arrayB[i-2] + g3*arrayB[i-3];
-    		arrayA[i] = g1*arrayA[i-1] + g2*arrayA[i-2] + g3*arrayA[i-3];
+            arrayB[i] = g1 * arrayB[i - 1] + g2 * arrayB[i - 2] + g3 * arrayB[i - 3];
+            arrayA[i] = g1 * arrayA[i - 1] + g2 * arrayA[i - 2] + g3 * arrayA[i - 3];
 
-    		xn3 = xn2;
-    		xn2 = xn1;
-    		xn1 = xn0;
-    		xn0 = xn0 + one;
-    		ct1 = ct1 + two;	
-    	}//end for	
+            xn3 = xn2;
+            xn2 = xn1;
+            xn1 = xn0;
+            xn0 = xn0 + one;
+            ct1 = ct1 + two;
+        }//end for
 
-    	arrayD[n1-1] = zero; 
-    	for (int j1 = 1; j1<=n+1; j1++){
-    		arrayR[j1-1] = (arrayA[j1-1])/(arrayB[j1-1]);//rational approximation of 1f1
-    		if (j1>1){
-    			arrayD[j1-2] = (arrayR[j1-1]) - (arrayR[j1-2]);
-    		}
-    		if (j1>=5 && Math.abs(arrayD[j1-2]/arrayR[j1-1])<= tolerance ){
-    			//checking for convergence of the rational approximation to a given tolerance
-    			//if that tolerance is met then exit the loop and return the value of the approximation
-    			return arrayR[j1-1];
-    		}//end if
-    		//if that tolerance is not met within the given numberof iterations then the program will
-    		//ask you to check the values entered
-    		if (j1 == n){
-    			throw new RuntimeException("please check your the values a, c & xin");
-    		}
-    	}//end for
+        arrayD[n1 - 1] = zero;
+        for (int j1 = 1; j1 <= n + 1; j1++) {
+            arrayR[j1 - 1] = (arrayA[j1 - 1]) / (arrayB[j1 - 1]);//rational approximation of 1f1
+            if (j1 > 1) {
+                arrayD[j1 - 2] = (arrayR[j1 - 1]) - (arrayR[j1 - 2]);
+            }
+            if (j1 >= 5 && Math.abs(arrayD[j1 - 2] / arrayR[j1 - 1]) <= tolerance) {
+                //checking for convergence of the rational approximation to a given tolerance
+                //if that tolerance is met then exit the loop and return the value of the approximation
+                return arrayR[j1 - 1];
+            }//end if
+            //if that tolerance is not met within the given numberof iterations then the program will
+            //ask you to check the values entered
+            if (j1 == n) {
+                throw new RuntimeException("please check your the values a, c & xin");
+            }
+        }//end for
 
-    	return arrayR[n];	
-    }//end main	
-
-    protected static double[] lp = new double[]{1};
-    protected static double lastLPX = 0;
-    protected static int maxLPN = 0;
+        return arrayR[n];
+    }//end main
 
     /**
      * Calculates Pn(x), Legendre polynomial of order n for the given input value.
-     * The method method makes use of a recursive method to calculate the return
+     * The method method makes use of recursion to calculate the return
      * value, so calling the method for all n in a sequence should not be much
      * more expensive than the call for the highest order.
+     *
+     * @param n order of the polynomial; must be non-negative.
+     * @param x argument of the polynomial.
+     * @throws IllegalArgumentException if n < 0.
      */
     public static double calcLegendrePolynomial(int n, double x) {
-        if (n==0 || (x == lastLPX && n<=maxLPN)) {
+        if (n < 0) {
+            throw new IllegalArgumentException("n must be non-negative");
+        }
+
+        if (n == 0 || (x == lastLPX && n <= maxLPN)) {
             return lp[n];
         }
         if (x != lastLPX) {
@@ -290,207 +248,109 @@ public final class SpecialFunctions {
         }
         if (n >= lp.length) {
             // increase size by 2 or 50%, whichever is greater
-            int newSize = n+2;
-            if (newSize < lp.length*3/2) {
-                newSize = lp.length*3/2;
+            int newSize = n + 2;
+            if (newSize < lp.length * 3 / 2) {
+                newSize = lp.length * 3 / 2;
             }
             double[] newLP = new double[newSize];
-            System.arraycopy(lp, 0, newLP, 0, maxLPN+1);
+            System.arraycopy(lp, 0, newLP, 0, maxLPN + 1);
             lp = newLP;
         }
         lp[1] = x;
-        if (maxLPN == 0) maxLPN=1;
-        for (int i=maxLPN+1; i<=n; i++) {
-            lp[i] = ((2*i-1)*x*lp[i-1] - (i-1)*lp[i-2])/i;
-            System.out.println((2*i-1)*x*lp[i-1]/i + " "+(1-i)*lp[i-2]/i+" "+lp[i]);
+        if (maxLPN == 0) maxLPN = 1;
+        for (int i = maxLPN + 1; i <= n; i++) {
+            lp[i] = ((2 * i - 1) * x * lp[i - 1] - (i - 1) * lp[i - 2]) / i;
+//            System.out.println((2*i-1)*x*lp[i-1]/i + " "+(1-i)*lp[i-2]/i+" "+lp[i]);
         }
         maxLPN = n;
         lastLPX = x;
         return lp[n];
     }
-    
-    protected static int nbin = 100;
-    protected static double [][] binom = new double [nbin][nbin];
+
 
     /**
-     * Returns the Wigner 3j symbol associated with coupling angular momenta in quantum mechanics.
-     * Reference for code that is commented out: (this code is not much robust)
-     * 1. http://mathworld.wolfram.com/Wigner3j-Symbol.html
-     * 2. http://massey.dur.ac.uk/umk/files/python/wigner.py
-     * Robust code taken from Bartolomei's pes-mrci.f file located at
-     * /usr/users/rsubrama/Desktop/Acads/Phd/oxygen/Bartolomei2010/
+     * Calculates the modified Bessel function of the first kind (I).
+     * Reference: http://mathworld.wolfram.com/ModifiedBesselFunctionoftheFirstKind.html
      *
-     * Currently only works for all 6 inputs being integers and not
-     * half integers
-     * @author rsubrama
-     * @return double w3j
+     * @param order of the Bessel function and it's a real number.
+     * @param x     the argument of the Bessel function
+     * @return modified Bessel function of the first kind to machine precision
      */
-    public static double wigner3J(int j1, int j2, int j3, int m1, int m2, int m3) {
-//        // Rule 1
-//        if (Math.abs(m1) > j1) return 0;
-//        if (Math.abs(m2) > j2) return 0;
-//        if (Math.abs(m3) > j3) return 0;
-//        
-//        // Rule 2
-//        if (m1 + m2 + m3 != 0) return 0;
-//        
-//        // Rule 3
-//        if (j3 > (j1 + j2) || j3 < Math.abs(j1 - j2)) return 0;
-//        
-//        int t1 = j2 - m1 - j3;
-//        int t2 = j1 + m2 - j3;
-//        int t3 = j1 + j2 - j3;
-//        int t4 = j1 - m1;
-//        int t5 = j2 + m2;
-//        
-//        int tMin = Math.max(0, Math.max(t1,t2));
-//        int tMax = Math.min(t3, Math.min(t4,t5)) + 1;
-//        int nTerms = tMax - tMin;
-//        
-//        // Check if number of terms is correct
-//        int [] n = new int [9];
-//        n[0] = j1 + m1;
-//        n[1] = t4;
-//        int gamma = Math.min(n[0],n[1]);        
-//        n[2] = t5;
-//        n[3] = j2 - m2;
-//        n[4] = j3 + m3;
-//        n[5] = j3 - m3;
-//        n[6] = j1 + j2 - j3;
-//        n[7] = j2 + j3 - j1;
-//        n[8] = j1 + j3 - j2;
-//        for (int i=2; i<9; i++) {
-//            gamma = Math.min(gamma, n[i]);
-//        }
-//        gamma ++;
-//        if (gamma != nTerms) throw new RuntimeException("Oops number of terms not matching!"+nTerms+gamma);
-//        
-//        double term1 = Math.pow(-1, j1 - j2 -m3);
-//        double term2 = Math.sqrt((double)factorial(n[6]) * (double)factorial(n[8]) * (double)factorial(n[7])/((double)factorial(j1 + j2 + j3 + 1)));
-//        double term3 = 1.00;
-//        for (int i=0; i<6; i++) {
-//            term3 *= (double)factorial(n[i]);
-//        }
-//        term3 = Math.sqrt(term3);
-//        double term4 = 0;
-//        for (int t = tMin; t < tMax; t++) {
-//            term4 += Math.pow(-1, t)/((double)factorial(t)*(double)factorial(t-t1)*(double)factorial(t-t2)*(double)factorial(t3-t)*(double)factorial(t4-t)*(double)factorial(t5-t));            
-//        }
-//        double w3j = term1*term2*term3*term4;
-        pascal();
-        double threej = 0.0;
-        if (m1+m2+m3 != 0.0) return threej;
-        int i1 = -j1 + j2 + j3 + 1;
-        if (i1 <= 0.0) return threej;
-        int i2 =  j1 - j2 + j3 + 1;
-        if (i2 <= 0.0) return threej;
-        int i3 =  j1 + j2 - j3 + 1;
-        if (i3 <= 0.0) return threej;
-        int k1 =  j1 + m1 + 1;
-        if (k1 <= 0.0) return threej;
-        int k2 =  j2 + m2 + 1;
-        if (k2 <= 0.0) return threej;
-        int k3 =  j3 + m3 + 1;
-        if (k3 <= 0.0) return threej;
-        int l1 =  j1 - m1 + 1;
-        if (l1 <= 0.0) return threej;
-        int l2 =  j2 - m2 + 1;
-        if (l2 <= 0.0) return threej;
-        int l3 =  j3 - m3 + 1;
-        if (l3 <= 0.0) return threej;
-        int n1 = -j1 - m2 + j3;
-        int n2 =  m1 - j2 + j3;
-        int n3 =  j1 - j2 + m3;
-//        System.out.println("i1 ="+i1+" i2 ="+i2+" i3 ="+i3+" k1 ="+k1+" k2 ="+k2+" k3 ="+k3+" l1 ="+l1+" l2 ="+l2+" l3 ="+l3+" n1 ="+n1+" n2 ="+n2+" n3 ="+n3);
-        int imin = Math.max(-n1,-n2);
-        imin = Math.max(imin, 0) + 1;
-        int imax = Math.min(l1,k2);
-        imax = Math.min(imax, i3);    
-        if (imin > imax) return threej;
-//        System.out.println("imin = "+imin+" imax = "+imax);
-        double sign = 1.0;
-        for (int i=imin; i<=imax; i++) {
-            sign = -sign;
-            threej += sign*binom[i1-1][n1+i-1]*binom[i2-1][n2+i-1]*binom[i3-1][i-1];
-        }
-        threej *= Math.sqrt(binom[j2+j2][i3-1]*binom[j1+j1][i2-1]/(binom[j1+j2+j3+1][i3-1]*(j3+j3+1.0)* binom[j1+j1][l1-1]*binom[j2+j2][l2-1]*binom[j3+j3][l3-1]));
-        if (n3+imin % 2 != 0) threej = - threej;
-        return threej;        
-    }
-    protected static void pascal() {
-        binom[0][0] = 1.0;
-        for (int i=2; i<=nbin; i++) {
-            binom[i-1][0] = 1.0;
-            binom[i-1][i-1] = 1.0;
-            if (i <= 2) continue;
-            int i1 = i - 1;
-            for (int j=2; j<=i1; j++) {
-                binom[i-1][j-1] = binom[i1-1][j-2] + binom[i1-1][j-1];
+    public static double besselI(double order, double x) {
+        double sum = 0;
+        double gammaValue = 0;
+        double kTerms = 0;
+        double factorial = 1;
+        double s1 = Math.pow(x / 2.0, order);
+
+        for (int k = 0; true; k++) {
+            factorial *= (k == 0) ? 1 : k;
+            gammaValue = gamma(k + order + 1);
+            kTerms = s1 * Math.pow((x * x) / 4.0, k) / factorial / gammaValue;
+            sum += kTerms;
+            if ((kTerms / sum) < 1E-15) {
+                break;
             }
         }
-    }   
-    
+        return sum;
+    }
+
+
     /**
-     * Calculates the modified bessel function of the first kind (I) for a given order and the variable x.
-     * Right now works only for integer orders.
-     * Reference: http://mathworld.wolfram.com/ModifiedBesselFunctionoftheFirstKind.html
-     * @author rsubrama
-     * @param order
-     * @param x
-     * @return double y
+     * Calculates the Bessel function of the first kind (J).
+     * Reference: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
+     *
+     * @param order of the Bessel function.
+     * @param x     the argument of the Bessel function.
+     * @return Bessel function of the first kind to machine precision.
      */
-    public static double besselI(int order, double x) {
-        if (x == 0) return 0;
-        if (Double.isInfinite(x) || Double.isNaN(x)) throw new IllegalArgumentException("Illegal argument "+x);
-        double term1 = Math.pow(0.5*x,order);
-        boolean done = false;
-        int k = 1;
-        double tol = 1E-10;
-        int maxK = 10000;
-        double newSum = 1.0;
-        double oldSum = 0.0;
-        double y1 = 1.0/factorial(order);
-        
-        do {
-            oldSum = newSum;
-            y1 *= x*x/(4.0*k*(k+order));            
-            newSum += y1;
-            double y2 = newSum - oldSum;
-            if (y2*y2 < tol) done = true;
-            k++;
-        } while (!done && k <= maxK);
-        if (!done) throw new RuntimeException("Failed to converge!!");
-        double y = term1*newSum;
-//        if (Double.isInfinite(y) || Double.isNaN(y)) throw new RuntimeException("Oops"+y);
-        return y;
-    }    
-    
+    public static double besselJ(double order, double x) {
+        double sum = 0;
+        double gammaValue = 0;
+        double kTerms = 0;
+        double factorial = 1;
+
+        for (int k = 0; true; k++) {
+            factorial *= (k == 0) ? 1 : -k;
+            gammaValue = gamma(k + order + 1);
+            kTerms = Math.pow(x / 2.0, 2 * k + order) / factorial / gammaValue;
+            sum += kTerms;
+            if ((Math.abs(kTerms / sum)) < 1E-15) {
+                break;
+            }
+
+        }
+        return sum;
+    }
+
 
     public static void main(String[] args) {
-    	System.out.println(confluentHypergeometric1F1(-0.25,0.5,1.0));
+        System.out.println(SpecialFunctions.besselJ(1.0,3));
+        System.exit(2);
+
+
+        System.out.println(confluentHypergeometric1F1(-0.25, 0.5, 1.0));
         System.out.println();
 
-        for (int i=-10; i<2; i++) {
-            double g = SpecialFunctions.gamma(i-0.5);
-            System.out.println((i-0.5)+" "+g); 
+        for (int i = -10; i < 2; i++) {
+            double g = SpecialFunctions.gamma(i - 0.5);
+            System.out.println((i - 0.5) + " " + g);
         }
-        System.out.println(0+" "+SpecialFunctions.gamma(0));
-        System.out.println(0.25+" "+SpecialFunctions.gamma(0.25)+" "+Math.exp(SpecialFunctions.lnGamma(0.25)));
-        System.out.println(0.5+" "+SpecialFunctions.gamma(0.5)+" "+Math.exp(SpecialFunctions.lnGamma(0.5)));
-        System.out.println(1+" "+SpecialFunctions.gamma(1));
+        System.out.println(0 + " " + SpecialFunctions.gamma(0));
+        System.out.println(0.25 + " " + SpecialFunctions.gamma(0.25) + " " + Math.exp(SpecialFunctions.lnGamma(0.25)));
+        System.out.println(0.5 + " " + SpecialFunctions.gamma(0.5) + " " + Math.exp(SpecialFunctions.lnGamma(0.5)));
+        System.out.println(1 + " " + SpecialFunctions.gamma(1));
         System.out.println();
 //    	for (int i=2; i<1000; i++) {
 //    	    double lnfac = SpecialFunctions.lnFactorial(i);
 //    	    System.out.println(i+" "+lnfac+" "+(SpecialFunctions.lnGamma(i+1)-lnfac)/lnfac);
 //    	}
-    	double w = SpecialFunctions.wigner3J(4, 2, 2, -2, 2, 0);
-    	System.out.println(w);
 //        System.out.println(besselI(0.32,0.25)+" "+besselI(-1.59, 0.25));
 //        double ap3 = SpecialFunctions.besselI(3, 200);
 //        System.out.println("ap3 = " + ap3);
-    	double a = 1E-24/Mole.UNIT.fromSim(1);
-    	System.out.println(a*a*3007.044183696613+" "+a*a*198.22529144211072);
-    	System.out.println(a*a*(-28532.603135414935+11560.282978358246)+" "+a*a*Math.sqrt(198.22529144211072*198.22529144211072 + 33.767924918154755*33.767924918154755));
-    
+        double a = 1E-24 / Mole.UNIT.fromSim(1);
+        System.out.println(a * a * 3007.044183696613 + " " + a * a * 198.22529144211072);
+        System.out.println(a * a * (-28532.603135414935 + 11560.282978358246) + " " + a * a * Math.sqrt(198.22529144211072 * 198.22529144211072 + 33.767924918154755 * 33.767924918154755));
+
     }
 }

--- a/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
+++ b/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
@@ -280,7 +280,7 @@ public final class SpecialFunctions {
      * @return modified Bessel function of the first kind to machine precision or
      * unmodified Bessel function of the first kind to the precision of 10E-13.
      */
-    public static double bessel(boolean modified, double order, double x) {
+    private static double bessel(boolean modified, double order, double x) {
         double sum = 0;
         double gammaValue = gamma(order);
         double kTerms = 0;
@@ -299,6 +299,29 @@ public final class SpecialFunctions {
         return sum;
     }
 
+    /**
+     * The modified Bessel function of the first kind, I
+     * Reference: http://mathworld.wolfram.com/ModifiedBesselFunctionoftheFirstKind.html
+     *
+     * @param order of the Bessel function
+     * @param x     the argument of the Bessel function
+     * @return modified Bessel function of the first kind, to machine precision.
+     */
+    public static double besselI(double order, double x) {
+        return bessel(true, order, x);
+    }
+
+    /**
+     * The unmodified Bessel function of the first kind, J.
+     * https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
+     *
+     * @param order of the Bessel function
+     * @param x     the argument of the Bessel function
+     * @return unmodified Bessel function of the first kind, to the precision of 1E-13.
+     */
+    public static double besselJ(double order, double x) {
+        return bessel(false, order, x);
+    }
 
     public static void main(String[] args) {
         System.out.println(SpecialFunctions.bessel(false, 1.0, 0.2));

--- a/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
+++ b/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
@@ -282,14 +282,14 @@ public final class SpecialFunctions {
      */
     public static double bessel(boolean modified, double order, double x) {
         double sum = 0;
-        double gammaValue = 0;
+        double gammaValue = gamma(order);
         double kTerms = 0;
         double factorial = 1;
         double s1 = Math.pow(x / 2.0, order);
 
         for (int k = 0; true; k++) {
             factorial *= (k == 0) ? 1 : (modified ? k : -k);
-            gammaValue = gamma(k + order + 1);
+            gammaValue *= order + k;
             kTerms = s1 * Math.pow((x * x) / 4.0, k) / factorial / gammaValue;
             sum += kTerms;
             if (Math.abs(kTerms / sum) < 1E-15) {

--- a/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
+++ b/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
@@ -4,9 +4,6 @@
 
 package etomica.math;
 
-import java.math.BigDecimal;
-
-import etomica.units.Dalton;
 import etomica.units.Mole;
 
 /**
@@ -18,12 +15,16 @@ public final class SpecialFunctions {
     
     /**
      * Complementary error function, computed using the approximant 7.1.26 of Abramowitz & Stegun.
-     * Defined for x >= 0
-     *
-     * Consider using {@link org.apache.commons.math3.special.Erf#erfc} if more precision is required.
-     * This method is substantially faster (~10x - 100x), but only accurate to ~10^-7.
+     * Absolute accuracy to within ~10^-7. If more precision is required,
+     * consider using {@link org.apache.commons.math3.special.Erf#erfc}, which is more accurate
+     * but substantially slower (~10x - 100x) than the method given here.
+     * @return value of complementary error function.
+     * @param x argument to function, may take values from  Double.NEGATIVE_INFINITY to Double.POSITIVE_INFINITY.
      */
     public static double erfc(double x) {
+        if (x < 0) {
+            return 2 - erfc(-x);
+        }
         double t = 1.0/(1.0 + 0.3275911*x);
         return (t * (
                   0.254829592 + t * (
@@ -80,13 +81,6 @@ public final class SpecialFunctions {
         return sum;
     }
 
-    /**
-     * The sign function, returning -1 if x < 0, zero if x == 0, and +1 if x > 0.
-     */
-    // TODO: all usages can just be converted to Math.signum
-    public static double sgn(double x) {
-        return (x < 0.0) ? -1.0 : ((x > 0.0) ? +1.0 : 0.0);
-    }
 
     /**
      * Returns the ln(gamma), the natural logarithm of the gamma function.
@@ -101,7 +95,7 @@ public final class SpecialFunctions {
             throw new IllegalArgumentException("x must not be negative");
         }
         if (x == 0) {
-            return 0;
+            return Double.POSITIVE_INFINITY;
         }
         if (x < 0.5) {
             return Math.log(Math.PI / (Math.sin(Math.PI*x))) - lnGamma(1-x);

--- a/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
+++ b/etomica-core/src/main/java/etomica/math/SpecialFunctions.java
@@ -269,14 +269,18 @@ public final class SpecialFunctions {
 
 
     /**
-     * Calculates the modified Bessel function of the first kind (I).
+     * Calculates the modified(or unmodified) Bessel function of the first kind (I or J).
      * Reference: http://mathworld.wolfram.com/ModifiedBesselFunctionoftheFirstKind.html
+     * https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
      *
-     * @param order of the Bessel function and it's a real number.
-     * @param x     the argument of the Bessel function
-     * @return modified Bessel function of the first kind to machine precision
+     * @param modified true return the modified Bessel function of the first kind I and
+     *                 false return the unmodified Bessel function of the first kind J.
+     * @param order    of the Bessel function and it's a real number.
+     * @param x        the argument of the Bessel function
+     * @return modified Bessel function of the first kind to machine precision or
+     * unmodified Bessel function of the first kind to the precision of 10E-13.
      */
-    public static double besselI(double order, double x) {
+    public static double bessel(boolean modified, double order, double x) {
         double sum = 0;
         double gammaValue = 0;
         double kTerms = 0;
@@ -284,48 +288,20 @@ public final class SpecialFunctions {
         double s1 = Math.pow(x / 2.0, order);
 
         for (int k = 0; true; k++) {
-            factorial *= (k == 0) ? 1 : k;
+            factorial *= (k == 0) ? 1 : (modified ? k : -k);
             gammaValue = gamma(k + order + 1);
             kTerms = s1 * Math.pow((x * x) / 4.0, k) / factorial / gammaValue;
             sum += kTerms;
-            if ((kTerms / sum) < 1E-15) {
+            if (Math.abs(kTerms / sum) < 1E-15) {
                 break;
             }
-        }
-        return sum;
-    }
-
-
-    /**
-     * Calculates the Bessel function of the first kind (J).
-     * Reference: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
-     *
-     * @param order of the Bessel function.
-     * @param x     the argument of the Bessel function.
-     * @return Bessel function of the first kind to machine precision.
-     */
-    public static double besselJ(double order, double x) {
-        double sum = 0;
-        double gammaValue = 0;
-        double kTerms = 0;
-        double factorial = 1;
-
-        for (int k = 0; true; k++) {
-            factorial *= (k == 0) ? 1 : -k;
-            gammaValue = gamma(k + order + 1);
-            kTerms = Math.pow(x / 2.0, 2 * k + order) / factorial / gammaValue;
-            sum += kTerms;
-            if ((Math.abs(kTerms / sum)) < 1E-15) {
-                break;
-            }
-
         }
         return sum;
     }
 
 
     public static void main(String[] args) {
-        System.out.println(SpecialFunctions.besselJ(1.0,3));
+        System.out.println(SpecialFunctions.bessel(false, 1.0, 0.2));
         System.exit(2);
 
 

--- a/etomica-core/src/main/java/etomica/space3d/BoundaryTruncatedOctahedron.java
+++ b/etomica-core/src/main/java/etomica/space3d/BoundaryTruncatedOctahedron.java
@@ -4,17 +4,16 @@
 
 package etomica.space3d;
 
-import etomica.space.Vector;
 import etomica.exception.MethodNotImplementedException;
 import etomica.lattice.IndexIteratorRectangular;
 import etomica.lattice.IndexIteratorSizable;
-import etomica.math.SpecialFunctions;
 import etomica.math.geometry.Plane;
 import etomica.math.geometry.Polygon;
 import etomica.math.geometry.Polyhedron;
 import etomica.math.geometry.TruncatedOctahedron;
 import etomica.space.Boundary;
 import etomica.space.Space;
+import etomica.space.Vector;
 
 /**
  * This class enables creation of a periodic truncated-octahedron boundary.
@@ -269,7 +268,7 @@ public class BoundaryTruncatedOctahedron extends Boundary {
             double corr = 0.5 * n * aint;
 
             for (int i=0; i<3; i++) {
-                rrounded.setX(i,SpecialFunctions.sgn(rrounded.getX(i)));
+                rrounded.setX(i, Math.signum(rrounded.getX(i)));
             }
             
             intoTruncatedOctahedron.PEa1Tv1(-corr, rrounded);

--- a/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
+++ b/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
@@ -237,606 +237,606 @@ public class SpecialFunctionsTest {
 
     @Test
     public void testBessel() throws Exception {
-        assertEquals(1.0, 0.1005008340281251 / SpecialFunctions.bessel(true, 1, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1005008340281251 / SpecialFunctions.besselI( 1, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.005016687513894678 / SpecialFunctions.bessel(true, 2, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 0.005016687513894678 / SpecialFunctions.besselI( 2, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0001670837502315642 / SpecialFunctions.bessel(true, 3, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0001670837502315642 / SpecialFunctions.besselI( 3, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.175006947752356E-6 / SpecialFunctions.bessel(true, 4, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 4.175006947752356E-6 / SpecialFunctions.besselI( 4, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.347232146991889E-8 / SpecialFunctions.bessel(true, 5, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 8.347232146991889E-8 / SpecialFunctions.besselI( 5, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2040267557335706 / SpecialFunctions.bessel(true, 1, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2040267557335706 / SpecialFunctions.besselI( 1, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.02026800356148826 / SpecialFunctions.bessel(true, 2, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.02026800356148826 / SpecialFunctions.besselI( 2, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.001346720118688000 / SpecialFunctions.bessel(true, 3, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.001346720118688000 / SpecialFunctions.besselI( 3, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.00006720178116825773 / SpecialFunctions.bessel(true, 4, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.00006720178116825773 / SpecialFunctions.besselI( 4, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.684495322845460E-6 / SpecialFunctions.bessel(true, 5, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 2.684495322845460E-6 / SpecialFunctions.besselI( 5, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3137040256049221 / SpecialFunctions.bessel(true, 1, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3137040256049221 / SpecialFunctions.besselI( 1, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.04636527896759911 / SpecialFunctions.bessel(true, 2, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.04636527896759911 / SpecialFunctions.besselI( 2, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.004602165820928096 / SpecialFunctions.bessel(true, 3, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.004602165820928096 / SpecialFunctions.besselI( 3, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0003436207583181480 / SpecialFunctions.bessel(true, 4, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0003436207583181480 / SpecialFunctions.besselI( 4, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.00002055571001945543 / SpecialFunctions.bessel(true, 5, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.00002055571001945543 / SpecialFunctions.besselI( 5, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.4328648026206398 / SpecialFunctions.bessel(true, 1, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.4328648026206398 / SpecialFunctions.besselI( 1, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.08435291631820318 / SpecialFunctions.bessel(true, 2, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.08435291631820318 / SpecialFunctions.besselI( 2, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01110022102962393 / SpecialFunctions.bessel(true, 3, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01110022102962393 / SpecialFunctions.besselI( 3, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.001101258596023714 / SpecialFunctions.bessel(true, 4, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.001101258596023714 / SpecialFunctions.besselI( 4, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.00008763506938678689 / SpecialFunctions.bessel(true, 5, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.00008763506938678689 / SpecialFunctions.besselI( 5, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5651591039924850 / SpecialFunctions.bessel(true, 1, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5651591039924850 / SpecialFunctions.besselI( 1, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1357476697670383 / SpecialFunctions.bessel(true, 2, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1357476697670383 / SpecialFunctions.besselI( 2, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.02216842492433190 / SpecialFunctions.bessel(true, 3, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.02216842492433190 / SpecialFunctions.besselI( 3, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.002737120221046866 / SpecialFunctions.bessel(true, 4, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.002737120221046866 / SpecialFunctions.besselI( 4, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0002714631559569719 / SpecialFunctions.bessel(true, 5, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0002714631559569719 / SpecialFunctions.besselI( 5, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.7146779415526431 / SpecialFunctions.bessel(true, 1, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.7146779415526431 / SpecialFunctions.besselI( 1, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2025956815463259 / SpecialFunctions.bessel(true, 2, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2025956815463259 / SpecialFunctions.besselI( 2, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.03935900306489002 / SpecialFunctions.bessel(true, 3, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.03935900306489002 / SpecialFunctions.besselI( 3, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.005800666221875796 / SpecialFunctions.bessel(true, 4, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.005800666221875796 / SpecialFunctions.besselI( 4, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0006878949190513823 / SpecialFunctions.bessel(true, 5, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0006878949190513823 / SpecialFunctions.besselI( 5, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.8860919814143274 / SpecialFunctions.bessel(true, 1, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.8860919814143274 / SpecialFunctions.besselI( 1, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2875494119964631 / SpecialFunctions.bessel(true, 2, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2875494119964631 / SpecialFunctions.besselI( 2, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.06452223285300407 / SpecialFunctions.bessel(true, 3, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.06452223285300407 / SpecialFunctions.besselI( 3, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01102555691215997 / SpecialFunctions.bessel(true, 4, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01102555691215997 / SpecialFunctions.besselI( 4, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.001519050497804235 / SpecialFunctions.bessel(true, 5, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.001519050497804235 / SpecialFunctions.besselI( 5, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.084810635129880 / SpecialFunctions.bessel(true, 1, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 1.084810635129880 / SpecialFunctions.besselI( 1, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3939673458265599 / SpecialFunctions.bessel(true, 2, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3939673458265599 / SpecialFunctions.besselI( 2, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.09989227056347994 / SpecialFunctions.bessel(true, 3, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.09989227056347994 / SpecialFunctions.besselI( 3, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01937133121351008 / SpecialFunctions.bessel(true, 4, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01937133121351008 / SpecialFunctions.besselI( 4, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.003035614495929543 / SpecialFunctions.bessel(true, 5, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.003035614495929543 / SpecialFunctions.besselI( 5, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.317167230391899 / SpecialFunctions.bessel(true, 1, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.317167230391899 / SpecialFunctions.besselI( 1, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5260402117381632 / SpecialFunctions.bessel(true, 2, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5260402117381632 / SpecialFunctions.besselI( 2, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1481889820848698 / SpecialFunctions.bessel(true, 3, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1481889820848698 / SpecialFunctions.besselI( 3, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.03207693812193060 / SpecialFunctions.bessel(true, 4, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.03207693812193060 / SpecialFunctions.besselI( 4, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.005624812654067089 / SpecialFunctions.bessel(true, 5, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.005624812654067089 / SpecialFunctions.besselI( 5, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.590636854637329 / SpecialFunctions.bessel(true, 1, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 1.590636854637329 / SpecialFunctions.besselI( 1, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.6889484476987382 / SpecialFunctions.bessel(true, 2, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.6889484476987382 / SpecialFunctions.besselI( 2, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2127399592398527 / SpecialFunctions.bessel(true, 3, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2127399592398527 / SpecialFunctions.besselI( 3, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.05072856997918024 / SpecialFunctions.bessel(true, 4, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.05072856997918024 / SpecialFunctions.besselI( 4, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.009825679323131702 / SpecialFunctions.bessel(true, 5, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.009825679323131702 / SpecialFunctions.besselI( 5, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.914094650586386 / SpecialFunctions.bessel(true, 1, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 1.914094650586386 / SpecialFunctions.besselI( 1, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.8890568175796904 / SpecialFunctions.bessel(true, 2, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.8890568175796904 / SpecialFunctions.besselI( 2, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2976277095324036 / SpecialFunctions.bessel(true, 3, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2976277095324036 / SpecialFunctions.besselI( 3, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.07734488249131686 / SpecialFunctions.bessel(true, 4, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.07734488249131686 / SpecialFunctions.besselI( 4, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01637359138216051 / SpecialFunctions.bessel(true, 5, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01637359138216051 / SpecialFunctions.besselI( 5, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.298123812543222 / SpecialFunctions.bessel(true, 1, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 2.298123812543222 / SpecialFunctions.besselI( 1, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.134153480870062 / SpecialFunctions.bessel(true, 2, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 1.134153480870062 / SpecialFunctions.besselI( 2, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.4078680110931191 / SpecialFunctions.bessel(true, 3, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.4078680110931191 / SpecialFunctions.besselI( 3, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1144834531372640 / SpecialFunctions.bessel(true, 4, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1144834531372640 / SpecialFunctions.besselI( 4, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.02625650063557234 / SpecialFunctions.bessel(true, 5, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.02625650063557234 / SpecialFunctions.besselI( 5, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.755384340504706 / SpecialFunctions.bessel(true, 1, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 2.755384340504706 / SpecialFunctions.besselI( 1, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.433742488470821 / SpecialFunctions.bessel(true, 2, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 1.433742488470821 / SpecialFunctions.besselI( 2, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5496266659342133 / SpecialFunctions.bessel(true, 3, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5496266659342133 / SpecialFunctions.besselI( 3, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1653732593918667 / SpecialFunctions.bessel(true, 4, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1653732593918667 / SpecialFunctions.besselI( 4, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.04078586780539262 / SpecialFunctions.bessel(true, 5, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.04078586780539262 / SpecialFunctions.besselI( 5, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.301055822635088 / SpecialFunctions.bessel(true, 1, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 3.301055822635088 / SpecialFunctions.besselI( 1, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.799400687332901 / SpecialFunctions.bessel(true, 2, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.799400687332901 / SpecialFunctions.besselI( 2, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.7304834121595154 / SpecialFunctions.bessel(true, 3, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.7304834121595154 / SpecialFunctions.besselI( 3, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2340790898482246 / SpecialFunctions.bessel(true, 4, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2340790898482246 / SpecialFunctions.besselI( 4, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.06168601259315954 / SpecialFunctions.bessel(true, 5, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.06168601259315954 / SpecialFunctions.besselI( 5, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.953370217402609 / SpecialFunctions.bessel(true, 1, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 3.953370217402609 / SpecialFunctions.besselI( 1, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.245212440929951 / SpecialFunctions.bessel(true, 2, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 2.245212440929951 / SpecialFunctions.besselI( 2, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.9597536294960079 / SpecialFunctions.bessel(true, 3, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.9597536294960079 / SpecialFunctions.besselI( 3, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3257051819379354 / SpecialFunctions.bessel(true, 4, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3257051819379354 / SpecialFunctions.besselI( 4, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.09120647766151335 / SpecialFunctions.bessel(true, 5, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.09120647766151335 / SpecialFunctions.besselI( 5, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.734253894709620 / SpecialFunctions.bessel(true, 1, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 4.734253894709620 / SpecialFunctions.besselI( 1, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.788298502987037 / SpecialFunctions.bessel(true, 2, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 2.788298502987037 / SpecialFunctions.besselI( 2, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.248880765975824 / SpecialFunctions.bessel(true, 3, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 1.248880765975824 / SpecialFunctions.besselI( 3, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.4466470667823664 / SpecialFunctions.bessel(true, 4, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.4466470667823664 / SpecialFunctions.besselI( 4, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1322630990199083 / SpecialFunctions.bessel(true, 5, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1322630990199083 / SpecialFunctions.besselI( 5, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.670102192635220 / SpecialFunctions.bessel(true, 1, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 5.670102192635220 / SpecialFunctions.besselI( 1, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.449458929469693 / SpecialFunctions.bessel(true, 2, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 3.449458929469693 / SpecialFunctions.besselI( 2, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.611915216788522 / SpecialFunctions.bessel(true, 3, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 1.611915216788522 / SpecialFunctions.besselI( 3, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.6049026645487712 / SpecialFunctions.bessel(true, 4, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.6049026645487712 / SpecialFunctions.besselI( 4, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1886148296149430 / SpecialFunctions.bessel(true, 5, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1886148296149430 / SpecialFunctions.besselI( 5, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.792714601361299 / SpecialFunctions.bessel(true, 1, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 6.792714601361299 / SpecialFunctions.besselI( 1, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.253954212964399 / SpecialFunctions.bessel(true, 2, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 4.253954212964399 / SpecialFunctions.besselI( 2, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.066098809178633 / SpecialFunctions.bessel(true, 3, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 2.066098809178633 / SpecialFunctions.besselI( 3, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.8104561976666769 / SpecialFunctions.bessel(true, 4, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.8104561976666769 / SpecialFunctions.besselI( 4, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2650850365860180 / SpecialFunctions.bessel(true, 5, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2650850365860180 / SpecialFunctions.besselI( 5, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.140424578907956 / SpecialFunctions.bessel(true, 1, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 8.140424578907956 / SpecialFunctions.besselI( 1, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.232454037200033 / SpecialFunctions.bessel(true, 2, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 5.232454037200033 / SpecialFunctions.besselI( 2, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.632578223960553 / SpecialFunctions.bessel(true, 3, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 2.632578223960553 / SpecialFunctions.besselI( 3, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.075751578314950 / SpecialFunctions.bessel(true, 4, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.075751578314950 / SpecialFunctions.besselI( 4, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3678380590869744 / SpecialFunctions.bessel(true, 5, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3678380590869744 / SpecialFunctions.besselI( 5, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 9.759465153704450 / SpecialFunctions.bessel(true, 1, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 9.759465153704450 / SpecialFunctions.besselI( 1, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.422189375284106 / SpecialFunctions.bessel(true, 2, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 6.422189375284106 / SpecialFunctions.besselI( 2, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.337275778420344 / SpecialFunctions.bessel(true, 3, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 3.337275778420344 / SpecialFunctions.besselI( 3, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.416275707653589 / SpecialFunctions.bessel(true, 4, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 1.416275707653589 / SpecialFunctions.besselI( 4, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5047243631131664 / SpecialFunctions.bessel(true, 5, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5047243631131664 / SpecialFunctions.besselI( 5, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 11.70562014305162 / SpecialFunctions.bessel(true, 1, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 11.70562014305162 / SpecialFunctions.besselI( 1, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 7.868351333273067 / SpecialFunctions.bessel(true, 2, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 7.868351333273067 / SpecialFunctions.besselI( 2, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.211952206601076 / SpecialFunctions.bessel(true, 3, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 4.211952206601076 / SpecialFunctions.besselI( 3, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.851276752414387 / SpecialFunctions.bessel(true, 4, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 1.851276752414387 / SpecialFunctions.besselI( 4, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.6857107734308141 / SpecialFunctions.bessel(true, 5, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.6857107734308141 / SpecialFunctions.besselI( 5, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 14.04622133753311 / SpecialFunctions.bessel(true, 1, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 14.04622133753311 / SpecialFunctions.besselI( 1, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 9.625789462431949 / SpecialFunctions.bessel(true, 2, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 9.625789462431949 / SpecialFunctions.besselI( 2, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.295503644413152 / SpecialFunctions.bessel(true, 3, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 5.295503644413152 / SpecialFunctions.besselI( 3, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.404648129141286 / SpecialFunctions.bessel(true, 4, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 2.404648129141286 / SpecialFunctions.besselI( 4, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.9234161368835410 / SpecialFunctions.bessel(true, 5, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.9234161368835410 / SpecialFunctions.besselI( 5, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 16.86256476197666 / SpecialFunctions.bessel(true, 1, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 16.86256476197666 / SpecialFunctions.besselI( 1, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 11.76107358300787 / SpecialFunctions.bessel(true, 2, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 11.76107358300787 / SpecialFunctions.besselI( 2, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.635544255013292 / SpecialFunctions.bessel(true, 3, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 6.635544255013292 / SpecialFunctions.besselI( 3, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.106015859077489 / SpecialFunctions.bessel(true, 4, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 3.106015859077489 / SpecialFunctions.besselI( 4, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.233777543574181 / SpecialFunctions.bessel(true, 5, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 1.233777543574181 / SpecialFunctions.besselI( 5, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 20.25283460023856 / SpecialFunctions.bessel(true, 1, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 20.25283460023856 / SpecialFunctions.besselI( 1, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 14.35499690967306 / SpecialFunctions.bessel(true, 2, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 14.35499690967306 / SpecialFunctions.besselI( 2, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.290337175511006 / SpecialFunctions.bessel(true, 3, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 8.290337175511006 / SpecialFunctions.besselI( 3, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.992075440284307 / SpecialFunctions.bessel(true, 4, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 3.992075440284307 / SpecialFunctions.besselI( 4, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.636878108370495 / SpecialFunctions.bessel(true, 5, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.636878108370495 / SpecialFunctions.besselI( 5, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 24.33564214245053 / SpecialFunctions.bessel(true, 1, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 24.33564214245053 / SpecialFunctions.besselI( 1, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 17.50561496662424 / SpecialFunctions.bessel(true, 2, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 17.50561496662424 / SpecialFunctions.besselI( 2, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 10.33115016915114 / SpecialFunctions.bessel(true, 3, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 10.33115016915114 / SpecialFunctions.besselI( 3, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.108234763642870 / SpecialFunctions.bessel(true, 4, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 5.108234763642870 / SpecialFunctions.besselI( 4, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.157974547322546 / SpecialFunctions.bessel(true, 5, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 2.157974547322546 / SpecialFunctions.besselI( 5, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 29.25430988179835 / SpecialFunctions.bessel(true, 1, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 29.25430988179835 / SpecialFunctions.besselI( 1, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 21.33193506376818 / SpecialFunctions.bessel(true, 2, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 21.33193506376818 / SpecialFunctions.besselI( 2, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 12.84512906351513 / SpecialFunctions.bessel(true, 3, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 12.84512906351513 / SpecialFunctions.besselI( 3, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.510632298173797 / SpecialFunctions.bessel(true, 4, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 6.510632298173797 / SpecialFunctions.besselI( 4, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.828771681709292 / SpecialFunctions.bessel(true, 5, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 2.828771681709292 / SpecialFunctions.besselI( 5, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 35.18205850608358 / SpecialFunctions.bessel(true, 1, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 35.18205850608358 / SpecialFunctions.besselI( 1, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 25.97839574633562 / SpecialFunctions.bessel(true, 2, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 25.97839574633562 / SpecialFunctions.besselI( 2, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 15.93880239768683 / SpecialFunctions.bessel(true, 3, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 15.93880239768683 / SpecialFunctions.besselI( 3, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.268615304461366 / SpecialFunctions.bessel(true, 4, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 8.268615304461366 / SpecialFunctions.besselI( 4, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.689001946632952 / SpecialFunctions.bessel(true, 5, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 3.689001946632952 / SpecialFunctions.besselI( 5, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 42.32828803246685 / SpecialFunctions.bessel(true, 1, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 42.32828803246685 / SpecialFunctions.besselI( 1, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 31.62030556675627 / SpecialFunctions.bessel(true, 2, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 31.62030556675627 / SpecialFunctions.besselI( 2, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 19.74235548478380 / SpecialFunctions.bessel(true, 3, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 19.74235548478380 / SpecialFunctions.besselI( 3, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 10.46778183305934 / SpecialFunctions.bessel(true, 4, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 10.46778183305934 / SpecialFunctions.besselI( 4, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.788381437556167 / SpecialFunctions.bessel(true, 5, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 4.788381437556167 / SpecialFunctions.besselI( 5, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 50.94618497877481 / SpecialFunctions.bessel(true, 1, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 50.94618497877481 / SpecialFunctions.besselI( 1, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 38.47044689994190 / SpecialFunctions.bessel(true, 2, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 38.47044689994190 / SpecialFunctions.besselI( 2, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 24.41484228915970 / SpecialFunctions.bessel(true, 3, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 24.41484228915970 / SpecialFunctions.besselI( 3, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 13.21371349736290 / SpecialFunctions.bessel(true, 4, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 13.21371349736290 / SpecialFunctions.besselI( 4, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.189030568659158 / SpecialFunctions.bessel(true, 5, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 6.189030568659158 / SpecialFunctions.besselI( 5, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 61.34193677764024 / SpecialFunctions.bessel(true, 1, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 61.34193677764024 / SpecialFunctions.besselI( 1, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 46.78709471726456 / SpecialFunctions.bessel(true, 2, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 46.78709471726456 / SpecialFunctions.besselI( 2, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 30.15054029946386 / SpecialFunctions.bessel(true, 3, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 30.15054029946386 / SpecialFunctions.besselI( 3, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 16.63655441780070 / SpecialFunctions.bessel(true, 4, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 16.63655441780070 / SpecialFunctions.besselI( 4, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 7.968467742396263 / SpecialFunctions.bessel(true, 5, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 7.968467742396263 / SpecialFunctions.besselI( 5, 6.0000000000000000000), 1E-14);
 
 
-        assertEquals(0.09950083263923600, SpecialFunctions.bessel(false, 1, 0.20000000000000000000), 1E-13);
+        assertEquals(0.09950083263923600, SpecialFunctions.besselJ( 1, 0.20000000000000000000), 1E-13);
 
-        assertEquals(0.004983354152783563, SpecialFunctions.bessel(false, 2, 0.20000000000000000000), 1E-13);
+        assertEquals(0.004983354152783563, SpecialFunctions.besselJ( 2, 0.20000000000000000000), 1E-13);
 
-        assertEquals(0.0001662504164352678, SpecialFunctions.bessel(false, 3, 0.20000000000000000000), 1E-13);
+        assertEquals(0.0001662504164352678, SpecialFunctions.besselJ( 3, 0.20000000000000000000), 1E-13);
 
-        assertEquals(4.158340274471933E-6, SpecialFunctions.bessel(false, 4, 0.20000000000000000000), 1E-13);
+        assertEquals(4.158340274471933E-6, SpecialFunctions.besselJ( 4, 0.20000000000000000000), 1E-13);
 
-        assertEquals(8.319454360946915E-8, SpecialFunctions.bessel(false, 5, 0.20000000000000000000), 1E-13);
+        assertEquals(8.319454360946915E-8, SpecialFunctions.besselJ( 5, 0.20000000000000000000), 1E-13);
 
-        assertEquals(0.1960265779553187, SpecialFunctions.bessel(false, 1, 0.40000000000000000000), 1E-13);
+        assertEquals(0.1960265779553187, SpecialFunctions.besselJ( 1, 0.40000000000000000000), 1E-13);
 
-        assertEquals(0.01973466311703027, SpecialFunctions.bessel(false, 2, 0.40000000000000000000), 1E-13);
+        assertEquals(0.01973466311703027, SpecialFunctions.besselJ( 2, 0.40000000000000000000), 1E-13);
 
-        assertEquals(0.001320053214983958, SpecialFunctions.bessel(false, 3, 0.40000000000000000000), 1E-13);
+        assertEquals(0.001320053214983958, SpecialFunctions.besselJ( 3, 0.40000000000000000000), 1E-13);
 
-        assertEquals(0.00006613510772909677, SpecialFunctions.bessel(false, 4, 0.40000000000000000000), 1E-13);
+        assertEquals(0.00006613510772909677, SpecialFunctions.besselJ( 4, 0.40000000000000000000), 1E-13);
 
-        assertEquals(2.648939597977585E-6, SpecialFunctions.bessel(false, 5, 0.40000000000000000000), 1E-13);
+        assertEquals(2.648939597977585E-6, SpecialFunctions.besselJ( 5, 0.40000000000000000000), 1E-13);
 
-        assertEquals(0.2867009880639157, SpecialFunctions.bessel(false, 1, 0.60000000000000000000), 1E-13);
+        assertEquals(0.2867009880639157, SpecialFunctions.besselJ( 1, 0.60000000000000000000), 1E-13);
 
-        assertEquals(0.04366509671584169, SpecialFunctions.bessel(false, 2, 0.60000000000000000000), 1E-13);
+        assertEquals(0.04366509671584169, SpecialFunctions.besselJ( 2, 0.60000000000000000000), 1E-13);
 
-        assertEquals(0.004399656708362193, SpecialFunctions.bessel(false, 3, 0.60000000000000000000), 1E-13);
+        assertEquals(0.004399656708362193, SpecialFunctions.besselJ( 3, 0.60000000000000000000), 1E-13);
 
-        assertEquals(0.0003314703677802370, SpecialFunctions.bessel(false, 4, 0.60000000000000000000), 1E-13);
+        assertEquals(0.0003314703677802370, SpecialFunctions.besselJ( 4, 0.60000000000000000000), 1E-13);
 
-        assertEquals(0.00001994819537430024, SpecialFunctions.bessel(false, 5, 0.60000000000000000000), 1E-13);
+        assertEquals(0.00001994819537430024, SpecialFunctions.besselJ( 5, 0.60000000000000000000), 1E-13);
 
-        assertEquals(0.3688420460941700, SpecialFunctions.bessel(false, 1, 0.80000000000000000000), 1E-13);
+        assertEquals(0.3688420460941700, SpecialFunctions.besselJ( 1, 0.80000000000000000000), 1E-13);
 
-        assertEquals(0.07581776248494472, SpecialFunctions.bessel(false, 2, 0.80000000000000000000), 1E-13);
+        assertEquals(0.07581776248494472, SpecialFunctions.besselJ( 2, 0.80000000000000000000), 1E-13);
 
-        assertEquals(0.01024676633055360, SpecialFunctions.bessel(false, 3, 0.80000000000000000000), 1E-13);
+        assertEquals(0.01024676633055360, SpecialFunctions.besselJ( 3, 0.80000000000000000000), 1E-13);
 
-        assertEquals(0.001032984994207302, SpecialFunctions.bessel(false, 4, 0.80000000000000000000), 1E-13);
+        assertEquals(0.001032984994207302, SpecialFunctions.besselJ( 4, 0.80000000000000000000), 1E-13);
 
-        assertEquals(0.00008308361151942143, SpecialFunctions.bessel(false, 5, 0.80000000000000000000), 1E-13);
+        assertEquals(0.00008308361151942143, SpecialFunctions.besselJ( 5, 0.80000000000000000000), 1E-13);
 
-        assertEquals(0.4400505857449335, SpecialFunctions.bessel(false, 1, 1.0000000000000000000), 1E-13);
+        assertEquals(0.4400505857449335, SpecialFunctions.besselJ( 1, 1.0000000000000000000), 1E-13);
 
-        assertEquals(0.1149034849319005, SpecialFunctions.bessel(false, 2, 1.0000000000000000000), 1E-13);
+        assertEquals(0.1149034849319005, SpecialFunctions.besselJ( 2, 1.0000000000000000000), 1E-13);
 
-        assertEquals(0.01956335398266841, SpecialFunctions.bessel(false, 3, 1.0000000000000000000), 1E-13);
+        assertEquals(0.01956335398266841, SpecialFunctions.besselJ( 3, 1.0000000000000000000), 1E-13);
 
-        assertEquals(0.002476638964109955, SpecialFunctions.bessel(false, 4, 1.0000000000000000000), 1E-13);
+        assertEquals(0.002476638964109955, SpecialFunctions.besselJ( 4, 1.0000000000000000000), 1E-13);
 
-        assertEquals(0.0002497577302112344, SpecialFunctions.bessel(false, 5, 1.0000000000000000000), 1E-13);
+        assertEquals(0.0002497577302112344, SpecialFunctions.besselJ( 5, 1.0000000000000000000), 1E-13);
 
-        assertEquals(0.4982890575672155, SpecialFunctions.bessel(false, 1, 1.2000000000000000000), 1E-13);
+        assertEquals(0.4982890575672155, SpecialFunctions.besselJ( 1, 1.2000000000000000000), 1E-13);
 
-        assertEquals(0.1593490183476631, SpecialFunctions.bessel(false, 2, 1.2000000000000000000), 1E-13);
+        assertEquals(0.1593490183476631, SpecialFunctions.besselJ( 2, 1.2000000000000000000), 1E-13);
 
-        assertEquals(0.03287433692499494, SpecialFunctions.bessel(false, 3, 1.2000000000000000000), 1E-13);
+        assertEquals(0.03287433692499494, SpecialFunctions.besselJ( 3, 1.2000000000000000000), 1E-13);
 
-        assertEquals(0.005022666277311587, SpecialFunctions.bessel(false, 4, 1.2000000000000000000), 1E-13);
+        assertEquals(0.005022666277311587, SpecialFunctions.besselJ( 4, 1.2000000000000000000), 1E-13);
 
-        assertEquals(0.0006101049237489684, SpecialFunctions.bessel(false, 5, 1.2000000000000000000), 1E-13);
+        assertEquals(0.0006101049237489684, SpecialFunctions.besselJ( 5, 1.2000000000000000000), 1E-13);
 
-        assertEquals(0.5419477139308545, SpecialFunctions.bessel(false, 1, 1.4000000000000000000), 1E-13);
+        assertEquals(0.5419477139308545, SpecialFunctions.besselJ( 1, 1.4000000000000000000), 1E-13);
 
-        assertEquals(0.2073558995269320, SpecialFunctions.bessel(false, 2, 1.4000000000000000000), 1E-13);
+        assertEquals(0.2073558995269320, SpecialFunctions.besselJ( 2, 1.4000000000000000000), 1E-13);
 
-        assertEquals(0.05049771328895130, SpecialFunctions.bessel(false, 3, 1.4000000000000000000), 1E-13);
+        assertEquals(0.05049771328895130, SpecialFunctions.besselJ( 3, 1.4000000000000000000), 1E-13);
 
-        assertEquals(0.009062871711430658, SpecialFunctions.bessel(false, 4, 1.4000000000000000000), 1E-13);
+        assertEquals(0.009062871711430658, SpecialFunctions.besselJ( 4, 1.4000000000000000000), 1E-13);
 
-        assertEquals(0.001290125062081034, SpecialFunctions.bessel(false, 5, 1.4000000000000000000), 1E-13);
+        assertEquals(0.001290125062081034, SpecialFunctions.besselJ( 5, 1.4000000000000000000), 1E-13);
 
-        assertEquals(0.5698959352616804, SpecialFunctions.bessel(false, 1, 1.6000000000000000000), 1E-13);
+        assertEquals(0.5698959352616804, SpecialFunctions.besselJ( 1, 1.6000000000000000000), 1E-13);
 
-        assertEquals(0.2569677514377197, SpecialFunctions.bessel(false, 2, 1.6000000000000000000), 1E-13);
+        assertEquals(0.2569677514377197, SpecialFunctions.besselJ( 2, 1.6000000000000000000), 1E-13);
 
-        assertEquals(0.07252344333261900, SpecialFunctions.bessel(false, 3, 1.6000000000000000000), 1E-13);
+        assertEquals(0.07252344333261900, SpecialFunctions.besselJ( 3, 1.6000000000000000000), 1E-13);
 
-        assertEquals(0.01499516105960151, SpecialFunctions.bessel(false, 4, 1.6000000000000000000), 1E-13);
+        assertEquals(0.01499516105960151, SpecialFunctions.besselJ( 4, 1.6000000000000000000), 1E-13);
 
-        assertEquals(0.002452361965388557, SpecialFunctions.bessel(false, 5, 1.6000000000000000000), 1E-13);
+        assertEquals(0.002452361965388557, SpecialFunctions.besselJ( 5, 1.6000000000000000000), 1E-13);
 
-        assertEquals(0.5815169517311652, SpecialFunctions.bessel(false, 1, 1.8000000000000000000), 1E-13);
+        assertEquals(0.5815169517311652, SpecialFunctions.besselJ( 1, 1.8000000000000000000), 1E-13);
 
-        assertEquals(0.3061435353254030, SpecialFunctions.bessel(false, 2, 1.8000000000000000000), 1E-13);
+        assertEquals(0.3061435353254030, SpecialFunctions.besselJ( 2, 1.8000000000000000000), 1E-13);
 
-        assertEquals(0.09880201565861918, SpecialFunctions.bessel(false, 3, 1.8000000000000000000), 1E-13);
+        assertEquals(0.09880201565861918, SpecialFunctions.besselJ( 3, 1.8000000000000000000), 1E-13);
 
-        assertEquals(0.02319651686999431, SpecialFunctions.bessel(false, 4, 1.8000000000000000000), 1E-13);
+        assertEquals(0.02319651686999431, SpecialFunctions.besselJ( 4, 1.8000000000000000000), 1E-13);
 
-        assertEquals(0.004293614874688868, SpecialFunctions.bessel(false, 5, 1.8000000000000000000), 1E-13);
+        assertEquals(0.004293614874688868, SpecialFunctions.besselJ( 5, 1.8000000000000000000), 1E-13);
 
-        assertEquals(0.5767248077568734, SpecialFunctions.bessel(false, 1, 2.0000000000000000000), 1E-13);
+        assertEquals(0.5767248077568734, SpecialFunctions.besselJ( 1, 2.0000000000000000000), 1E-13);
 
-        assertEquals(0.3528340286156377, SpecialFunctions.bessel(false, 2, 2.0000000000000000000), 1E-13);
+        assertEquals(0.3528340286156377, SpecialFunctions.besselJ( 2, 2.0000000000000000000), 1E-13);
 
-        assertEquals(0.1289432494744021, SpecialFunctions.bessel(false, 3, 2.0000000000000000000), 1E-13);
+        assertEquals(0.1289432494744021, SpecialFunctions.besselJ( 3, 2.0000000000000000000), 1E-13);
 
-        assertEquals(0.03399571980756843, SpecialFunctions.bessel(false, 4, 2.0000000000000000000), 1E-13);
+        assertEquals(0.03399571980756843, SpecialFunctions.besselJ( 4, 2.0000000000000000000), 1E-13);
 
-        assertEquals(0.007039629755871685, SpecialFunctions.bessel(false, 5, 2.0000000000000000000), 1E-13);
+        assertEquals(0.007039629755871685, SpecialFunctions.besselJ( 5, 2.0000000000000000000), 1E-13);
 
-        assertEquals(0.5559630498190639, SpecialFunctions.bessel(false, 1, 2.2000000000000000000), 1E-13);
+        assertEquals(0.5559630498190639, SpecialFunctions.besselJ( 1, 2.2000000000000000000), 1E-13);
 
-        assertEquals(0.3950586874587933, SpecialFunctions.bessel(false, 2, 2.2000000000000000000), 1E-13);
+        assertEquals(0.3950586874587933, SpecialFunctions.besselJ( 2, 2.2000000000000000000), 1E-13);
 
-        assertEquals(0.1623254728332875, SpecialFunctions.bessel(false, 3, 2.2000000000000000000), 1E-13);
+        assertEquals(0.1623254728332875, SpecialFunctions.besselJ( 3, 2.2000000000000000000), 1E-13);
 
-        assertEquals(0.04764714754108161, SpecialFunctions.bessel(false, 4, 2.2000000000000000000), 1E-13);
+        assertEquals(0.04764714754108161, SpecialFunctions.besselJ( 4, 2.2000000000000000000), 1E-13);
 
-        assertEquals(0.01093688186155476, SpecialFunctions.bessel(false, 5, 2.2000000000000000000), 1E-13);
+        assertEquals(0.01093688186155476, SpecialFunctions.besselJ( 5, 2.2000000000000000000), 1E-13);
 
-        assertEquals(0.5201852681819310, SpecialFunctions.bessel(false, 1, 2.4000000000000000000), 1E-13);
+        assertEquals(0.5201852681819310, SpecialFunctions.besselJ( 1, 2.4000000000000000000), 1E-13);
 
-        assertEquals(0.4309800401876987, SpecialFunctions.bessel(false, 2, 2.4000000000000000000), 1E-13);
+        assertEquals(0.4309800401876987, SpecialFunctions.besselJ( 2, 2.4000000000000000000), 1E-13);
 
-        assertEquals(0.1981147987975668, SpecialFunctions.bessel(false, 3, 2.4000000000000000000), 1E-13);
+        assertEquals(0.1981147987975668, SpecialFunctions.besselJ( 3, 2.4000000000000000000), 1E-13);
 
-        assertEquals(0.06430695680621835, SpecialFunctions.bessel(false, 4, 2.4000000000000000000), 1E-13);
+        assertEquals(0.06430695680621835, SpecialFunctions.besselJ( 4, 2.4000000000000000000), 1E-13);
 
-        assertEquals(0.01624172388982766, SpecialFunctions.bessel(false, 5, 2.4000000000000000000), 1E-13);
+        assertEquals(0.01624172388982766, SpecialFunctions.besselJ( 5, 2.4000000000000000000), 1E-13);
 
-        assertEquals(0.4708182665175787, SpecialFunctions.bessel(false, 1, 2.6000000000000000000), 1E-13);
+        assertEquals(0.4708182665175787, SpecialFunctions.besselJ( 1, 2.6000000000000000000), 1E-13);
 
-        assertEquals(0.4589728517182526, SpecialFunctions.bessel(false, 2, 2.6000000000000000000), 1E-13);
+        assertEquals(0.4589728517182526, SpecialFunctions.besselJ( 2, 2.6000000000000000000), 1E-13);
 
-        assertEquals(0.2352938130489638, SpecialFunctions.bessel(false, 3, 2.6000000000000000000), 1E-13);
+        assertEquals(0.2352938130489638, SpecialFunctions.besselJ( 3, 2.6000000000000000000), 1E-13);
 
-        assertEquals(0.08401287070243310, SpecialFunctions.bessel(false, 4, 2.6000000000000000000), 1E-13);
+        assertEquals(0.08401287070243310, SpecialFunctions.besselJ( 4, 2.6000000000000000000), 1E-13);
 
-        assertEquals(0.02320732757390727, SpecialFunctions.bessel(false, 5, 2.6000000000000000000), 1E-13);
+        assertEquals(0.02320732757390727, SpecialFunctions.besselJ( 5, 2.6000000000000000000), 1E-13);
 
-        assertEquals(0.4097092468522887, SpecialFunctions.bessel(false, 1, 2.8000000000000000000), 1E-13);
+        assertEquals(0.4097092468522887, SpecialFunctions.besselJ( 1, 2.8000000000000000000), 1E-13);
 
-        assertEquals(0.4776854954017364, SpecialFunctions.bessel(false, 2, 2.8000000000000000000), 1E-13);
+        assertEquals(0.4776854954017364, SpecialFunctions.besselJ( 2, 2.8000000000000000000), 1E-13);
 
-        assertEquals(0.2726986037216204, SpecialFunctions.bessel(false, 3, 2.8000000000000000000), 1E-13);
+        assertEquals(0.2726986037216204, SpecialFunctions.besselJ( 3, 2.8000000000000000000), 1E-13);
 
-        assertEquals(0.1066686554303074, SpecialFunctions.bessel(false, 4, 2.8000000000000000000), 1E-13);
+        assertEquals(0.1066686554303074, SpecialFunctions.besselJ( 4, 2.8000000000000000000), 1E-13);
 
-        assertEquals(0.03206898322211490, SpecialFunctions.bessel(false, 5, 2.8000000000000000000), 1E-13);
+        assertEquals(0.03206898322211490, SpecialFunctions.besselJ( 5, 2.8000000000000000000), 1E-13);
 
-        assertEquals(0.3390589585259365, SpecialFunctions.bessel(false, 1, 3.0000000000000000000), 1E-13);
+        assertEquals(0.3390589585259365, SpecialFunctions.besselJ( 1, 3.0000000000000000000), 1E-13);
 
-        assertEquals(0.4860912605858911, SpecialFunctions.bessel(false, 2, 3.0000000000000000000), 1E-13);
+        assertEquals(0.4860912605858911, SpecialFunctions.besselJ( 2, 3.0000000000000000000), 1E-13);
 
-        assertEquals(0.3090627222552516, SpecialFunctions.bessel(false, 3, 3.0000000000000000000), 1E-13);
+        assertEquals(0.3090627222552516, SpecialFunctions.besselJ( 3, 3.0000000000000000000), 1E-13);
 
-        assertEquals(0.1320341839246122, SpecialFunctions.bessel(false, 4, 3.0000000000000000000), 1E-13);
+        assertEquals(0.1320341839246122, SpecialFunctions.besselJ( 4, 3.0000000000000000000), 1E-13);
 
-        assertEquals(0.04302843487704758, SpecialFunctions.bessel(false, 5, 3.0000000000000000000), 1E-13);
+        assertEquals(0.04302843487704758, SpecialFunctions.besselJ( 5, 3.0000000000000000000), 1E-13);
 
-        assertEquals(0.2613432487805048, SpecialFunctions.bessel(false, 1, 3.2000000000000000000), 1E-13);
+        assertEquals(0.2613432487805048, SpecialFunctions.besselJ( 1, 3.2000000000000000000), 1E-13);
 
-        assertEquals(0.4835277001449384, SpecialFunctions.bessel(false, 2, 3.2000000000000000000), 1E-13);
+        assertEquals(0.4835277001449384, SpecialFunctions.besselJ( 2, 3.2000000000000000000), 1E-13);
 
-        assertEquals(0.3430663764006682, SpecialFunctions.bessel(false, 3, 3.2000000000000000000), 1E-13);
+        assertEquals(0.3430663764006682, SpecialFunctions.besselJ( 3, 3.2000000000000000000), 1E-13);
 
-        assertEquals(0.1597217556063144, SpecialFunctions.bessel(false, 4, 3.2000000000000000000), 1E-13);
+        assertEquals(0.1597217556063144, SpecialFunctions.besselJ( 4, 3.2000000000000000000), 1E-13);
 
-        assertEquals(0.05623801261511791, SpecialFunctions.bessel(false, 5, 3.2000000000000000000), 1E-13);
+        assertEquals(0.05623801261511791, SpecialFunctions.besselJ( 5, 3.2000000000000000000), 1E-13);
 
-        assertEquals(0.1792258516815071, SpecialFunctions.bessel(false, 1, 3.4000000000000000000), 1E-13);
+        assertEquals(0.1792258516815071, SpecialFunctions.besselJ( 1, 3.4000000000000000000), 1E-13);
 
-        assertEquals(0.4697225683393576, SpecialFunctions.bessel(false, 2, 3.4000000000000000000), 1E-13);
+        assertEquals(0.4697225683393576, SpecialFunctions.besselJ( 2, 3.4000000000000000000), 1E-13);
 
-        assertEquals(0.3733889346000901, SpecialFunctions.bessel(false, 3, 3.4000000000000000000), 1E-13);
+        assertEquals(0.3733889346000901, SpecialFunctions.besselJ( 3, 3.4000000000000000000), 1E-13);
 
-        assertEquals(0.1891990809549190, SpecialFunctions.bessel(false, 4, 3.4000000000000000000), 1E-13);
+        assertEquals(0.1891990809549190, SpecialFunctions.besselJ( 4, 3.4000000000000000000), 1E-13);
 
-        assertEquals(0.07178537352913107, SpecialFunctions.bessel(false, 5, 3.4000000000000000000), 1E-13);
+        assertEquals(0.07178537352913107, SpecialFunctions.besselJ( 5, 3.4000000000000000000), 1E-13);
 
-        assertEquals(0.09546554717787640, SpecialFunctions.bessel(false, 1, 3.6000000000000000000), 1E-13);
+        assertEquals(0.09546554717787640, SpecialFunctions.besselJ( 1, 3.6000000000000000000), 1E-13);
 
-        assertEquals(0.4448053987996180, SpecialFunctions.bessel(false, 2, 3.6000000000000000000), 1E-13);
+        assertEquals(0.4448053987996180, SpecialFunctions.besselJ( 2, 3.6000000000000000000), 1E-13);
 
-        assertEquals(0.3987626737105880, SpecialFunctions.bessel(false, 3, 3.6000000000000000000), 1E-13);
+        assertEquals(0.3987626737105880, SpecialFunctions.besselJ( 3, 3.6000000000000000000), 1E-13);
 
-        assertEquals(0.2197990573846954, SpecialFunctions.bessel(false, 4, 3.6000000000000000000), 1E-13);
+        assertEquals(0.2197990573846954, SpecialFunctions.besselJ( 4, 3.6000000000000000000), 1E-13);
 
-        assertEquals(0.08967967603317951, SpecialFunctions.bessel(false, 5, 3.6000000000000000000), 1E-13);
+        assertEquals(0.08967967603317951, SpecialFunctions.besselJ( 5, 3.6000000000000000000), 1E-13);
 
-        assertEquals(0.01282100292673163, SpecialFunctions.bessel(false, 1, 3.8000000000000000000), 1E-13);
+        assertEquals(0.01282100292673163, SpecialFunctions.besselJ( 1, 3.8000000000000000000), 1E-13);
 
-        assertEquals(0.4093043064557913, SpecialFunctions.bessel(false, 2, 3.8000000000000000000), 1E-13);
+        assertEquals(0.4093043064557913, SpecialFunctions.besselJ( 2, 3.8000000000000000000), 1E-13);
 
-        assertEquals(0.4180256354477856, SpecialFunctions.bessel(false, 3, 3.8000000000000000000), 1E-13);
+        assertEquals(0.4180256354477856, SpecialFunctions.besselJ( 3, 3.8000000000000000000), 1E-13);
 
-        assertEquals(0.2507361705670280, SpecialFunctions.bessel(false, 4, 3.8000000000000000000), 1E-13);
+        assertEquals(0.2507361705670280, SpecialFunctions.besselJ( 4, 3.8000000000000000000), 1E-13);
 
-        assertEquals(0.1098399867985891, SpecialFunctions.bessel(false, 5, 3.8000000000000000000), 1E-13);
+        assertEquals(0.1098399867985891, SpecialFunctions.besselJ( 5, 3.8000000000000000000), 1E-13);
 
-        assertEquals(-0.06604332802354914, SpecialFunctions.bessel(false, 1, 4.0000000000000000000), 1E-13);
+        assertEquals(-0.06604332802354914, SpecialFunctions.besselJ( 1, 4.0000000000000000000), 1E-13);
 
-        assertEquals(0.3641281458520728, SpecialFunctions.bessel(false, 2, 4.0000000000000000000), 1E-13);
+        assertEquals(0.3641281458520728, SpecialFunctions.besselJ( 2, 4.0000000000000000000), 1E-13);
 
-        assertEquals(0.4301714738756219, SpecialFunctions.bessel(false, 3, 4.0000000000000000000), 1E-13);
+        assertEquals(0.4301714738756219, SpecialFunctions.besselJ( 3, 4.0000000000000000000), 1E-13);
 
-        assertEquals(0.2811290649613601, SpecialFunctions.bessel(false, 4, 4.0000000000000000000), 1E-13);
+        assertEquals(0.2811290649613601, SpecialFunctions.besselJ( 4, 4.0000000000000000000), 1E-13);
 
-        assertEquals(0.1320866560470983, SpecialFunctions.bessel(false, 5, 4.0000000000000000000), 1E-13);
+        assertEquals(0.1320866560470983, SpecialFunctions.besselJ( 5, 4.0000000000000000000), 1E-13);
 
-        assertEquals(-0.1386469421260462, SpecialFunctions.bessel(false, 1, 4.2000000000000000000), 1E-13);
+        assertEquals(-0.1386469421260462, SpecialFunctions.besselJ( 1, 4.2000000000000000000), 1E-13);
 
-        assertEquals(0.3105347009742123, SpecialFunctions.bessel(false, 2, 4.2000000000000000000), 1E-13);
+        assertEquals(0.3105347009742123, SpecialFunctions.besselJ( 2, 4.2000000000000000000), 1E-13);
 
-        assertEquals(0.4343942763872008, SpecialFunctions.bessel(false, 3, 4.2000000000000000000), 1E-13);
+        assertEquals(0.4343942763872008, SpecialFunctions.besselJ( 3, 4.2000000000000000000), 1E-13);
 
-        assertEquals(0.3100285510075031, SpecialFunctions.bessel(false, 4, 4.2000000000000000000), 1E-13);
+        assertEquals(0.3100285510075031, SpecialFunctions.besselJ( 4, 4.2000000000000000000), 1E-13);
 
-        assertEquals(0.1561362969604241, SpecialFunctions.bessel(false, 5, 4.2000000000000000000), 1E-13);
+        assertEquals(0.1561362969604241, SpecialFunctions.besselJ( 5, 4.2000000000000000000), 1E-13);
 
-        assertEquals(-0.2027755219230866, SpecialFunctions.bessel(false, 1, 4.4000000000000000000), 1E-13);
+        assertEquals(-0.2027755219230866, SpecialFunctions.besselJ( 1, 4.4000000000000000000), 1E-13);
 
-        assertEquals(0.2500860982206644, SpecialFunctions.bessel(false, 2, 4.4000000000000000000), 1E-13);
+        assertEquals(0.2500860982206644, SpecialFunctions.besselJ( 2, 4.4000000000000000000), 1E-13);
 
-        assertEquals(0.4301265203055088, SpecialFunctions.bessel(false, 3, 4.4000000000000000000), 1E-13);
+        assertEquals(0.4301265203055088, SpecialFunctions.besselJ( 3, 4.4000000000000000000), 1E-13);
 
-        assertEquals(0.3364500658323021, SpecialFunctions.bessel(false, 4, 4.4000000000000000000), 1E-13);
+        assertEquals(0.3364500658323021, SpecialFunctions.besselJ( 4, 4.4000000000000000000), 1E-13);
 
-        assertEquals(0.1816008721168587, SpecialFunctions.bessel(false, 5, 4.4000000000000000000), 1E-13);
+        assertEquals(0.1816008721168587, SpecialFunctions.besselJ( 5, 4.4000000000000000000), 1E-13);
 
-        assertEquals(-0.2565528360974446, SpecialFunctions.bessel(false, 1, 4.6000000000000000000), 1E-13);
+        assertEquals(-0.2565528360974446, SpecialFunctions.besselJ( 1, 4.6000000000000000000), 1E-13);
 
-        assertEquals(0.1845931052274261, SpecialFunctions.bessel(false, 2, 4.6000000000000000000), 1E-13);
+        assertEquals(0.1845931052274261, SpecialFunctions.besselJ( 2, 4.6000000000000000000), 1E-13);
 
-        assertEquals(0.4170685797734673, SpecialFunctions.bessel(false, 3, 4.6000000000000000000), 1E-13);
+        assertEquals(0.4170685797734673, SpecialFunctions.besselJ( 3, 4.6000000000000000000), 1E-13);
 
-        assertEquals(0.3594093901292703, SpecialFunctions.bessel(false, 4, 4.6000000000000000000), 1E-13);
+        assertEquals(0.3594093901292703, SpecialFunctions.besselJ( 4, 4.6000000000000000000), 1E-13);
 
-        assertEquals(0.2079912291470029, SpecialFunctions.bessel(false, 5, 4.6000000000000000000), 1E-13);
+        assertEquals(0.2079912291470029, SpecialFunctions.besselJ( 5, 4.6000000000000000000), 1E-13);
 
-        assertEquals(-0.2984998580995579, SpecialFunctions.bessel(false, 1, 4.8000000000000000000), 1E-13);
+        assertEquals(-0.2984998580995579, SpecialFunctions.besselJ( 1, 4.8000000000000000000), 1E-13);
 
-        assertEquals(0.1160503864163677, SpecialFunctions.bessel(false, 2, 4.8000000000000000000), 1E-13);
+        assertEquals(0.1160503864163677, SpecialFunctions.besselJ( 2, 4.8000000000000000000), 1E-13);
 
-        assertEquals(0.3952085134465309, SpecialFunctions.bessel(false, 3, 4.8000000000000000000), 1E-13);
+        assertEquals(0.3952085134465309, SpecialFunctions.besselJ( 3, 4.8000000000000000000), 1E-13);
 
-        assertEquals(0.3779602553917960, SpecialFunctions.bessel(false, 4, 4.8000000000000000000), 1E-13);
+        assertEquals(0.3779602553917960, SpecialFunctions.besselJ( 4, 4.8000000000000000000), 1E-13);
 
-        assertEquals(0.2347252455397957, SpecialFunctions.bessel(false, 5, 4.8000000000000000000), 1E-13);
+        assertEquals(0.2347252455397957, SpecialFunctions.besselJ( 5, 4.8000000000000000000), 1E-13);
 
-        assertEquals(-0.3275791375914652, SpecialFunctions.bessel(false, 1, 5.0000000000000000000), 1E-13);
+        assertEquals(-0.3275791375914652, SpecialFunctions.besselJ( 1, 5.0000000000000000000), 1E-13);
 
-        assertEquals(0.04656511627775222, SpecialFunctions.bessel(false, 2, 5.0000000000000000000), 1E-13);
+        assertEquals(0.04656511627775222, SpecialFunctions.besselJ( 2, 5.0000000000000000000), 1E-13);
 
-        assertEquals(0.3648312306136670, SpecialFunctions.bessel(false, 3, 5.0000000000000000000), 1E-13);
+        assertEquals(0.3648312306136670, SpecialFunctions.besselJ( 3, 5.0000000000000000000), 1E-13);
 
-        assertEquals(0.3912323604586482, SpecialFunctions.bessel(false, 4, 5.0000000000000000000), 1E-13);
+        assertEquals(0.3912323604586482, SpecialFunctions.besselJ( 4, 5.0000000000000000000), 1E-13);
 
-        assertEquals(0.2611405461201701, SpecialFunctions.bessel(false, 5, 5.0000000000000000000), 1E-13);
+        assertEquals(0.2611405461201701, SpecialFunctions.besselJ( 5, 5.0000000000000000000), 1E-13);
 
-        assertEquals(-0.3432230058719219, SpecialFunctions.bessel(false, 1, 5.2000000000000000000), 1E-13);
+        assertEquals(-0.3432230058719219, SpecialFunctions.besselJ( 1, 5.2000000000000000000), 1E-13);
 
-        assertEquals(-0.02171840862129112, SpecialFunctions.bessel(false, 2, 5.2000000000000000000), 1E-13);
+        assertEquals(-0.02171840862129112, SpecialFunctions.besselJ( 2, 5.2000000000000000000), 1E-13);
 
-        assertEquals(0.3265165377016980, SpecialFunctions.bessel(false, 3, 5.2000000000000000000), 1E-13);
+        assertEquals(0.3265165377016980, SpecialFunctions.besselJ( 3, 5.2000000000000000000), 1E-13);
 
-        assertEquals(0.3984682598155580, SpecialFunctions.bessel(false, 4, 5.2000000000000000000), 1E-13);
+        assertEquals(0.3984682598155580, SpecialFunctions.besselJ( 4, 5.2000000000000000000), 1E-13);
 
-        assertEquals(0.2865115543222374, SpecialFunctions.bessel(false, 5, 5.2000000000000000000), 1E-13);
+        assertEquals(0.2865115543222374, SpecialFunctions.besselJ( 5, 5.2000000000000000000), 1E-13);
 
-        assertEquals(-0.3453447907795863, SpecialFunctions.bessel(false, 1, 5.4000000000000000000), 1E-13);
+        assertEquals(-0.3453447907795863, SpecialFunctions.besselJ( 1, 5.4000000000000000000), 1E-13);
 
-        assertEquals(-0.08669537682152215, SpecialFunctions.bessel(false, 2, 5.4000000000000000000), 1E-13);
+        assertEquals(-0.08669537682152215, SpecialFunctions.besselJ( 2, 5.4000000000000000000), 1E-13);
 
-        assertEquals(0.2811259931340144, SpecialFunctions.bessel(false, 3, 5.4000000000000000000), 1E-13);
+        assertEquals(0.2811259931340144, SpecialFunctions.besselJ( 3, 5.4000000000000000000), 1E-13);
 
-        assertEquals(0.3990575914148714, SpecialFunctions.bessel(false, 4, 5.4000000000000000000), 1E-13);
+        assertEquals(0.3990575914148714, SpecialFunctions.besselJ( 4, 5.4000000000000000000), 1E-13);
 
-        assertEquals(0.3100704385917211, SpecialFunctions.bessel(false, 5, 5.4000000000000000000), 1E-13);
+        assertEquals(0.3100704385917211, SpecialFunctions.besselJ( 5, 5.4000000000000000000), 1E-13);
 
-        assertEquals(-0.3343328362910075, SpecialFunctions.bessel(false, 1, 5.6000000000000000000), 1E-13);
+        assertEquals(-0.3343328362910075, SpecialFunctions.besselJ( 1, 5.6000000000000000000), 1E-13);
 
-        assertEquals(-0.1463754690747600, SpecialFunctions.bessel(false, 2, 5.6000000000000000000), 1E-13);
+        assertEquals(-0.1463754690747600, SpecialFunctions.besselJ( 2, 5.6000000000000000000), 1E-13);
 
-        assertEquals(0.2297789298090361, SpecialFunctions.bessel(false, 3, 5.6000000000000000000), 1E-13);
+        assertEquals(0.2297789298090361, SpecialFunctions.besselJ( 3, 5.6000000000000000000), 1E-13);
 
-        assertEquals(0.3925671795844415, SpecialFunctions.bessel(false, 4, 5.6000000000000000000), 1E-13);
+        assertEquals(0.3925671795844415, SpecialFunctions.besselJ( 4, 5.6000000000000000000), 1E-13);
 
-        assertEquals(0.3310313267401661, SpecialFunctions.bessel(false, 5, 5.6000000000000000000), 1E-13);
+        assertEquals(0.3310313267401661, SpecialFunctions.besselJ( 5, 5.6000000000000000000), 1E-13);
 
-        assertEquals(-0.3110277443039424, SpecialFunctions.bessel(false, 1, 5.8000000000000000000), 1E-13);
+        assertEquals(-0.3110277443039424, SpecialFunctions.besselJ( 1, 5.8000000000000000000), 1E-13);
 
-        assertEquals(-0.1989535138865205, SpecialFunctions.bessel(false, 2, 5.8000000000000000000), 1E-13);
+        assertEquals(-0.1989535138865205, SpecialFunctions.besselJ( 2, 5.8000000000000000000), 1E-13);
 
-        assertEquals(0.1738184243822042, SpecialFunctions.bessel(false, 3, 5.8000000000000000000), 1E-13);
+        assertEquals(0.1738184243822042, SpecialFunctions.besselJ( 3, 5.8000000000000000000), 1E-13);
 
-        assertEquals(0.3787656770405248, SpecialFunctions.bessel(false, 4, 5.8000000000000000000), 1E-13);
+        assertEquals(0.3787656770405248, SpecialFunctions.besselJ( 4, 5.8000000000000000000), 1E-13);
 
-        assertEquals(0.3486169922254162, SpecialFunctions.bessel(false, 5, 5.8000000000000000000), 1E-13);
+        assertEquals(0.3486169922254162, SpecialFunctions.besselJ( 5, 5.8000000000000000000), 1E-13);
 
-        assertEquals(-0.2766838581275656, SpecialFunctions.bessel(false, 1, 6.0000000000000000000), 1E-13);
+        assertEquals(-0.2766838581275656, SpecialFunctions.besselJ( 1, 6.0000000000000000000), 1E-13);
 
-        assertEquals(-0.2428732099601855, SpecialFunctions.bessel(false, 2, 6.0000000000000000000), 1E-13);
+        assertEquals(-0.2428732099601855, SpecialFunctions.besselJ( 2, 6.0000000000000000000), 1E-13);
 
-        assertEquals(0.1147683848207753, SpecialFunctions.bessel(false, 3, 6.0000000000000000000), 1E-13);
+        assertEquals(0.1147683848207753, SpecialFunctions.besselJ( 3, 6.0000000000000000000), 1E-13);
 
-        assertEquals(0.3576415947809608, SpecialFunctions.bessel(false, 4, 6.0000000000000000000), 1E-13);
+        assertEquals(0.3576415947809608, SpecialFunctions.besselJ( 4, 6.0000000000000000000), 1E-13);
 
-        assertEquals(0.3620870748871724, SpecialFunctions.bessel(false, 5, 6.0000000000000000000), 1E-13);
+        assertEquals(0.3620870748871724, SpecialFunctions.besselJ( 5, 6.0000000000000000000), 1E-13);
 
     }
 

--- a/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
+++ b/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
@@ -4,12 +4,63 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by alex on 4/24/17.
  */
 public class SpecialFunctionsTest {
+    private double epislon = 1E-7;
+
+    @Test
+    public void testErfc() throws Exception {
+        for (double x = -10; x < 10.0001; x += 0.1) {
+            assertEquals(org.apache.commons.math3.special.Erf.erfc(x), SpecialFunctions.erfc(x), 2E-7);
+        }
+
+    }
+
+
+    @Test
+    public void testLnGamma() throws Exception {
+        for (double x = 0.1; x < 10.01; x += 0.1) {
+            if (Math.abs(SpecialFunctions.lnGamma(x)) < 1.0) {
+                assertEquals(org.apache.commons.math3.special.Gamma.logGamma(x), SpecialFunctions.lnGamma(x), 1E-14);
+            } else {
+                assertEquals(1.0, org.apache.commons.math3.special.Gamma.logGamma(x) / SpecialFunctions.lnGamma(x), 1E-14);
+            }
+        }
+    }
+
+    @Test
+    public void testGamma() throws Exception {
+    }
+
+    @Test
+    public void testGammaQ() throws Exception {
+    }
+
+    @Test
+    public void testConfluentHypergeometric1F1() throws Exception {
+    }
+
+    @Test
+    public void testCalcLegendrePolynomial() throws Exception {
+    }
+
+    @Test
+    public void testWigner3J() throws Exception {
+    }
+
+    @Test
+    public void testPascal() throws Exception {
+    }
+
+    @Test
+    public void testBesselI() throws Exception {
+    }
+
+
     private static final double EPSILON = 1e-10;
 
     @Rule

--- a/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
+++ b/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
@@ -236,611 +236,610 @@ public class SpecialFunctionsTest {
     }
 
     @Test
-    public void testBesselI() throws Exception {
-        assertEquals(1.0, 0.1005008340281251 / SpecialFunctions.besselI(1, 0.20000000000000000000), 1E-14);
+    public void testBessel() throws Exception {
+        assertEquals(1.0, 0.1005008340281251 / SpecialFunctions.bessel(true, 1, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.005016687513894678 / SpecialFunctions.besselI(2, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 0.005016687513894678 / SpecialFunctions.bessel(true, 2, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0001670837502315642 / SpecialFunctions.besselI(3, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0001670837502315642 / SpecialFunctions.bessel(true, 3, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.175006947752356E-6 / SpecialFunctions.besselI(4, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 4.175006947752356E-6 / SpecialFunctions.bessel(true, 4, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.347232146991889E-8 / SpecialFunctions.besselI(5, 0.20000000000000000000), 1E-14);
+        assertEquals(1.0, 8.347232146991889E-8 / SpecialFunctions.bessel(true, 5, 0.20000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2040267557335706 / SpecialFunctions.besselI(1, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2040267557335706 / SpecialFunctions.bessel(true, 1, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.02026800356148826 / SpecialFunctions.besselI(2, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.02026800356148826 / SpecialFunctions.bessel(true, 2, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.001346720118688000 / SpecialFunctions.besselI(3, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.001346720118688000 / SpecialFunctions.bessel(true, 3, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.00006720178116825773 / SpecialFunctions.besselI(4, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 0.00006720178116825773 / SpecialFunctions.bessel(true, 4, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.684495322845460E-6 / SpecialFunctions.besselI(5, 0.40000000000000000000), 1E-14);
+        assertEquals(1.0, 2.684495322845460E-6 / SpecialFunctions.bessel(true, 5, 0.40000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3137040256049221 / SpecialFunctions.besselI(1, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3137040256049221 / SpecialFunctions.bessel(true, 1, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.04636527896759911 / SpecialFunctions.besselI(2, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.04636527896759911 / SpecialFunctions.bessel(true, 2, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.004602165820928096 / SpecialFunctions.besselI(3, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.004602165820928096 / SpecialFunctions.bessel(true, 3, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0003436207583181480 / SpecialFunctions.besselI(4, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0003436207583181480 / SpecialFunctions.bessel(true, 4, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.00002055571001945543 / SpecialFunctions.besselI(5, 0.60000000000000000000), 1E-14);
+        assertEquals(1.0, 0.00002055571001945543 / SpecialFunctions.bessel(true, 5, 0.60000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.4328648026206398 / SpecialFunctions.besselI(1, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.4328648026206398 / SpecialFunctions.bessel(true, 1, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.08435291631820318 / SpecialFunctions.besselI(2, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.08435291631820318 / SpecialFunctions.bessel(true, 2, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01110022102962393 / SpecialFunctions.besselI(3, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01110022102962393 / SpecialFunctions.bessel(true, 3, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.001101258596023714 / SpecialFunctions.besselI(4, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.001101258596023714 / SpecialFunctions.bessel(true, 4, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.00008763506938678689 / SpecialFunctions.besselI(5, 0.80000000000000000000), 1E-14);
+        assertEquals(1.0, 0.00008763506938678689 / SpecialFunctions.bessel(true, 5, 0.80000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5651591039924850 / SpecialFunctions.besselI(1, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5651591039924850 / SpecialFunctions.bessel(true, 1, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1357476697670383 / SpecialFunctions.besselI(2, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1357476697670383 / SpecialFunctions.bessel(true, 2, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.02216842492433190 / SpecialFunctions.besselI(3, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.02216842492433190 / SpecialFunctions.bessel(true, 3, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.002737120221046866 / SpecialFunctions.besselI(4, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.002737120221046866 / SpecialFunctions.bessel(true, 4, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0002714631559569719 / SpecialFunctions.besselI(5, 1.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0002714631559569719 / SpecialFunctions.bessel(true, 5, 1.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.7146779415526431 / SpecialFunctions.besselI(1, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.7146779415526431 / SpecialFunctions.bessel(true, 1, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2025956815463259 / SpecialFunctions.besselI(2, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2025956815463259 / SpecialFunctions.bessel(true, 2, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.03935900306489002 / SpecialFunctions.besselI(3, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.03935900306489002 / SpecialFunctions.bessel(true, 3, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.005800666221875796 / SpecialFunctions.besselI(4, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.005800666221875796 / SpecialFunctions.bessel(true, 4, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.0006878949190513823 / SpecialFunctions.besselI(5, 1.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.0006878949190513823 / SpecialFunctions.bessel(true, 5, 1.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.8860919814143274 / SpecialFunctions.besselI(1, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.8860919814143274 / SpecialFunctions.bessel(true, 1, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2875494119964631 / SpecialFunctions.besselI(2, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2875494119964631 / SpecialFunctions.bessel(true, 2, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.06452223285300407 / SpecialFunctions.besselI(3, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.06452223285300407 / SpecialFunctions.bessel(true, 3, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01102555691215997 / SpecialFunctions.besselI(4, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01102555691215997 / SpecialFunctions.bessel(true, 4, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.001519050497804235 / SpecialFunctions.besselI(5, 1.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.001519050497804235 / SpecialFunctions.bessel(true, 5, 1.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.084810635129880 / SpecialFunctions.besselI(1, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 1.084810635129880 / SpecialFunctions.bessel(true, 1, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3939673458265599 / SpecialFunctions.besselI(2, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3939673458265599 / SpecialFunctions.bessel(true, 2, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.09989227056347994 / SpecialFunctions.besselI(3, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.09989227056347994 / SpecialFunctions.bessel(true, 3, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01937133121351008 / SpecialFunctions.besselI(4, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01937133121351008 / SpecialFunctions.bessel(true, 4, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.003035614495929543 / SpecialFunctions.besselI(5, 1.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.003035614495929543 / SpecialFunctions.bessel(true, 5, 1.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.317167230391899 / SpecialFunctions.besselI(1, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.317167230391899 / SpecialFunctions.bessel(true, 1, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5260402117381632 / SpecialFunctions.besselI(2, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5260402117381632 / SpecialFunctions.bessel(true, 2, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1481889820848698 / SpecialFunctions.besselI(3, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1481889820848698 / SpecialFunctions.bessel(true, 3, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.03207693812193060 / SpecialFunctions.besselI(4, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.03207693812193060 / SpecialFunctions.bessel(true, 4, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.005624812654067089 / SpecialFunctions.besselI(5, 1.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.005624812654067089 / SpecialFunctions.bessel(true, 5, 1.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.590636854637329 / SpecialFunctions.besselI(1, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 1.590636854637329 / SpecialFunctions.bessel(true, 1, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.6889484476987382 / SpecialFunctions.besselI(2, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.6889484476987382 / SpecialFunctions.bessel(true, 2, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2127399592398527 / SpecialFunctions.besselI(3, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2127399592398527 / SpecialFunctions.bessel(true, 3, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.05072856997918024 / SpecialFunctions.besselI(4, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.05072856997918024 / SpecialFunctions.bessel(true, 4, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.009825679323131702 / SpecialFunctions.besselI(5, 2.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.009825679323131702 / SpecialFunctions.bessel(true, 5, 2.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.914094650586386 / SpecialFunctions.besselI(1, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 1.914094650586386 / SpecialFunctions.bessel(true, 1, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.8890568175796904 / SpecialFunctions.besselI(2, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.8890568175796904 / SpecialFunctions.bessel(true, 2, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2976277095324036 / SpecialFunctions.besselI(3, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2976277095324036 / SpecialFunctions.bessel(true, 3, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.07734488249131686 / SpecialFunctions.besselI(4, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.07734488249131686 / SpecialFunctions.bessel(true, 4, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.01637359138216051 / SpecialFunctions.besselI(5, 2.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.01637359138216051 / SpecialFunctions.bessel(true, 5, 2.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.298123812543222 / SpecialFunctions.besselI(1, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 2.298123812543222 / SpecialFunctions.bessel(true, 1, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.134153480870062 / SpecialFunctions.besselI(2, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 1.134153480870062 / SpecialFunctions.bessel(true, 2, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.4078680110931191 / SpecialFunctions.besselI(3, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.4078680110931191 / SpecialFunctions.bessel(true, 3, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1144834531372640 / SpecialFunctions.besselI(4, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1144834531372640 / SpecialFunctions.bessel(true, 4, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.02625650063557234 / SpecialFunctions.besselI(5, 2.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.02625650063557234 / SpecialFunctions.bessel(true, 5, 2.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.755384340504706 / SpecialFunctions.besselI(1, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 2.755384340504706 / SpecialFunctions.bessel(true, 1, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.433742488470821 / SpecialFunctions.besselI(2, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 1.433742488470821 / SpecialFunctions.bessel(true, 2, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5496266659342133 / SpecialFunctions.besselI(3, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5496266659342133 / SpecialFunctions.bessel(true, 3, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1653732593918667 / SpecialFunctions.besselI(4, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1653732593918667 / SpecialFunctions.bessel(true, 4, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.04078586780539262 / SpecialFunctions.besselI(5, 2.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.04078586780539262 / SpecialFunctions.bessel(true, 5, 2.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.301055822635088 / SpecialFunctions.besselI(1, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 3.301055822635088 / SpecialFunctions.bessel(true, 1, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.799400687332901 / SpecialFunctions.besselI(2, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.799400687332901 / SpecialFunctions.bessel(true, 2, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.7304834121595154 / SpecialFunctions.besselI(3, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.7304834121595154 / SpecialFunctions.bessel(true, 3, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2340790898482246 / SpecialFunctions.besselI(4, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2340790898482246 / SpecialFunctions.bessel(true, 4, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.06168601259315954 / SpecialFunctions.besselI(5, 2.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.06168601259315954 / SpecialFunctions.bessel(true, 5, 2.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.953370217402609 / SpecialFunctions.besselI(1, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 3.953370217402609 / SpecialFunctions.bessel(true, 1, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.245212440929951 / SpecialFunctions.besselI(2, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 2.245212440929951 / SpecialFunctions.bessel(true, 2, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.9597536294960079 / SpecialFunctions.besselI(3, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.9597536294960079 / SpecialFunctions.bessel(true, 3, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3257051819379354 / SpecialFunctions.besselI(4, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3257051819379354 / SpecialFunctions.bessel(true, 4, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.09120647766151335 / SpecialFunctions.besselI(5, 3.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.09120647766151335 / SpecialFunctions.bessel(true, 5, 3.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.734253894709620 / SpecialFunctions.besselI(1, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 4.734253894709620 / SpecialFunctions.bessel(true, 1, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.788298502987037 / SpecialFunctions.besselI(2, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 2.788298502987037 / SpecialFunctions.bessel(true, 2, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.248880765975824 / SpecialFunctions.besselI(3, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 1.248880765975824 / SpecialFunctions.bessel(true, 3, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.4466470667823664 / SpecialFunctions.besselI(4, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.4466470667823664 / SpecialFunctions.bessel(true, 4, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1322630990199083 / SpecialFunctions.besselI(5, 3.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1322630990199083 / SpecialFunctions.bessel(true, 5, 3.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.670102192635220 / SpecialFunctions.besselI(1, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 5.670102192635220 / SpecialFunctions.bessel(true, 1, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.449458929469693 / SpecialFunctions.besselI(2, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 3.449458929469693 / SpecialFunctions.bessel(true, 2, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.611915216788522 / SpecialFunctions.besselI(3, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 1.611915216788522 / SpecialFunctions.bessel(true, 3, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.6049026645487712 / SpecialFunctions.besselI(4, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.6049026645487712 / SpecialFunctions.bessel(true, 4, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.1886148296149430 / SpecialFunctions.besselI(5, 3.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.1886148296149430 / SpecialFunctions.bessel(true, 5, 3.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.792714601361299 / SpecialFunctions.besselI(1, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 6.792714601361299 / SpecialFunctions.bessel(true, 1, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.253954212964399 / SpecialFunctions.besselI(2, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 4.253954212964399 / SpecialFunctions.bessel(true, 2, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.066098809178633 / SpecialFunctions.besselI(3, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 2.066098809178633 / SpecialFunctions.bessel(true, 3, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.8104561976666769 / SpecialFunctions.besselI(4, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.8104561976666769 / SpecialFunctions.bessel(true, 4, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.2650850365860180 / SpecialFunctions.besselI(5, 3.6000000000000000000), 1E-14);
+        assertEquals(1.0, 0.2650850365860180 / SpecialFunctions.bessel(true, 5, 3.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.140424578907956 / SpecialFunctions.besselI(1, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 8.140424578907956 / SpecialFunctions.bessel(true, 1, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.232454037200033 / SpecialFunctions.besselI(2, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 5.232454037200033 / SpecialFunctions.bessel(true, 2, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.632578223960553 / SpecialFunctions.besselI(3, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 2.632578223960553 / SpecialFunctions.bessel(true, 3, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.075751578314950 / SpecialFunctions.besselI(4, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.075751578314950 / SpecialFunctions.bessel(true, 4, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.3678380590869744 / SpecialFunctions.besselI(5, 3.8000000000000000000), 1E-14);
+        assertEquals(1.0, 0.3678380590869744 / SpecialFunctions.bessel(true, 5, 3.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 9.759465153704450 / SpecialFunctions.besselI(1, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 9.759465153704450 / SpecialFunctions.bessel(true, 1, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.422189375284106 / SpecialFunctions.besselI(2, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 6.422189375284106 / SpecialFunctions.bessel(true, 2, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.337275778420344 / SpecialFunctions.besselI(3, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 3.337275778420344 / SpecialFunctions.bessel(true, 3, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.416275707653589 / SpecialFunctions.besselI(4, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 1.416275707653589 / SpecialFunctions.bessel(true, 4, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.5047243631131664 / SpecialFunctions.besselI(5, 4.0000000000000000000), 1E-14);
+        assertEquals(1.0, 0.5047243631131664 / SpecialFunctions.bessel(true, 5, 4.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 11.70562014305162 / SpecialFunctions.besselI(1, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 11.70562014305162 / SpecialFunctions.bessel(true, 1, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 7.868351333273067 / SpecialFunctions.besselI(2, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 7.868351333273067 / SpecialFunctions.bessel(true, 2, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.211952206601076 / SpecialFunctions.besselI(3, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 4.211952206601076 / SpecialFunctions.bessel(true, 3, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.851276752414387 / SpecialFunctions.besselI(4, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 1.851276752414387 / SpecialFunctions.bessel(true, 4, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.6857107734308141 / SpecialFunctions.besselI(5, 4.2000000000000000000), 1E-14);
+        assertEquals(1.0, 0.6857107734308141 / SpecialFunctions.bessel(true, 5, 4.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 14.04622133753311 / SpecialFunctions.besselI(1, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 14.04622133753311 / SpecialFunctions.bessel(true, 1, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 9.625789462431949 / SpecialFunctions.besselI(2, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 9.625789462431949 / SpecialFunctions.bessel(true, 2, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.295503644413152 / SpecialFunctions.besselI(3, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 5.295503644413152 / SpecialFunctions.bessel(true, 3, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.404648129141286 / SpecialFunctions.besselI(4, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 2.404648129141286 / SpecialFunctions.bessel(true, 4, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 0.9234161368835410 / SpecialFunctions.besselI(5, 4.4000000000000000000), 1E-14);
+        assertEquals(1.0, 0.9234161368835410 / SpecialFunctions.bessel(true, 5, 4.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 16.86256476197666 / SpecialFunctions.besselI(1, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 16.86256476197666 / SpecialFunctions.bessel(true, 1, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 11.76107358300787 / SpecialFunctions.besselI(2, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 11.76107358300787 / SpecialFunctions.bessel(true, 2, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.635544255013292 / SpecialFunctions.besselI(3, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 6.635544255013292 / SpecialFunctions.bessel(true, 3, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.106015859077489 / SpecialFunctions.besselI(4, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 3.106015859077489 / SpecialFunctions.bessel(true, 4, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.233777543574181 / SpecialFunctions.besselI(5, 4.6000000000000000000), 1E-14);
+        assertEquals(1.0, 1.233777543574181 / SpecialFunctions.bessel(true, 5, 4.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 20.25283460023856 / SpecialFunctions.besselI(1, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 20.25283460023856 / SpecialFunctions.bessel(true, 1, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 14.35499690967306 / SpecialFunctions.besselI(2, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 14.35499690967306 / SpecialFunctions.bessel(true, 2, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.290337175511006 / SpecialFunctions.besselI(3, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 8.290337175511006 / SpecialFunctions.bessel(true, 3, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.992075440284307 / SpecialFunctions.besselI(4, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 3.992075440284307 / SpecialFunctions.bessel(true, 4, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 1.636878108370495 / SpecialFunctions.besselI(5, 4.8000000000000000000), 1E-14);
+        assertEquals(1.0, 1.636878108370495 / SpecialFunctions.bessel(true, 5, 4.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 24.33564214245053 / SpecialFunctions.besselI(1, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 24.33564214245053 / SpecialFunctions.bessel(true, 1, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 17.50561496662424 / SpecialFunctions.besselI(2, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 17.50561496662424 / SpecialFunctions.bessel(true, 2, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 10.33115016915114 / SpecialFunctions.besselI(3, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 10.33115016915114 / SpecialFunctions.bessel(true, 3, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 5.108234763642870 / SpecialFunctions.besselI(4, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 5.108234763642870 / SpecialFunctions.bessel(true, 4, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.157974547322546 / SpecialFunctions.besselI(5, 5.0000000000000000000), 1E-14);
+        assertEquals(1.0, 2.157974547322546 / SpecialFunctions.bessel(true, 5, 5.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 29.25430988179835 / SpecialFunctions.besselI(1, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 29.25430988179835 / SpecialFunctions.bessel(true, 1, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 21.33193506376818 / SpecialFunctions.besselI(2, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 21.33193506376818 / SpecialFunctions.bessel(true, 2, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 12.84512906351513 / SpecialFunctions.besselI(3, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 12.84512906351513 / SpecialFunctions.bessel(true, 3, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.510632298173797 / SpecialFunctions.besselI(4, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 6.510632298173797 / SpecialFunctions.bessel(true, 4, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 2.828771681709292 / SpecialFunctions.besselI(5, 5.2000000000000000000), 1E-14);
+        assertEquals(1.0, 2.828771681709292 / SpecialFunctions.bessel(true, 5, 5.2000000000000000000), 1E-14);
 
-        assertEquals(1.0, 35.18205850608358 / SpecialFunctions.besselI(1, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 35.18205850608358 / SpecialFunctions.bessel(true, 1, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 25.97839574633562 / SpecialFunctions.besselI(2, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 25.97839574633562 / SpecialFunctions.bessel(true, 2, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 15.93880239768683 / SpecialFunctions.besselI(3, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 15.93880239768683 / SpecialFunctions.bessel(true, 3, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 8.268615304461366 / SpecialFunctions.besselI(4, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 8.268615304461366 / SpecialFunctions.bessel(true, 4, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 3.689001946632952 / SpecialFunctions.besselI(5, 5.4000000000000000000), 1E-14);
+        assertEquals(1.0, 3.689001946632952 / SpecialFunctions.bessel(true, 5, 5.4000000000000000000), 1E-14);
 
-        assertEquals(1.0, 42.32828803246685 / SpecialFunctions.besselI(1, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 42.32828803246685 / SpecialFunctions.bessel(true, 1, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 31.62030556675627 / SpecialFunctions.besselI(2, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 31.62030556675627 / SpecialFunctions.bessel(true, 2, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 19.74235548478380 / SpecialFunctions.besselI(3, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 19.74235548478380 / SpecialFunctions.bessel(true, 3, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 10.46778183305934 / SpecialFunctions.besselI(4, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 10.46778183305934 / SpecialFunctions.bessel(true, 4, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 4.788381437556167 / SpecialFunctions.besselI(5, 5.6000000000000000000), 1E-14);
+        assertEquals(1.0, 4.788381437556167 / SpecialFunctions.bessel(true, 5, 5.6000000000000000000), 1E-14);
 
-        assertEquals(1.0, 50.94618497877481 / SpecialFunctions.besselI(1, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 50.94618497877481 / SpecialFunctions.bessel(true, 1, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 38.47044689994190 / SpecialFunctions.besselI(2, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 38.47044689994190 / SpecialFunctions.bessel(true, 2, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 24.41484228915970 / SpecialFunctions.besselI(3, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 24.41484228915970 / SpecialFunctions.bessel(true, 3, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 13.21371349736290 / SpecialFunctions.besselI(4, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 13.21371349736290 / SpecialFunctions.bessel(true, 4, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 6.189030568659158 / SpecialFunctions.besselI(5, 5.8000000000000000000), 1E-14);
+        assertEquals(1.0, 6.189030568659158 / SpecialFunctions.bessel(true, 5, 5.8000000000000000000), 1E-14);
 
-        assertEquals(1.0, 61.34193677764024 / SpecialFunctions.besselI(1, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 61.34193677764024 / SpecialFunctions.bessel(true, 1, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 46.78709471726456 / SpecialFunctions.besselI(2, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 46.78709471726456 / SpecialFunctions.bessel(true, 2, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 30.15054029946386 / SpecialFunctions.besselI(3, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 30.15054029946386 / SpecialFunctions.bessel(true, 3, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 16.63655441780070 / SpecialFunctions.besselI(4, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 16.63655441780070 / SpecialFunctions.bessel(true, 4, 6.0000000000000000000), 1E-14);
 
-        assertEquals(1.0, 7.968467742396263 / SpecialFunctions.besselI(5, 6.0000000000000000000), 1E-14);
+        assertEquals(1.0, 7.968467742396263 / SpecialFunctions.bessel(true, 5, 6.0000000000000000000), 1E-14);
+
+
+        assertEquals(0.09950083263923600, SpecialFunctions.bessel(false, 1, 0.20000000000000000000), 1E-13);
+
+        assertEquals(0.004983354152783563, SpecialFunctions.bessel(false, 2, 0.20000000000000000000), 1E-13);
+
+        assertEquals(0.0001662504164352678, SpecialFunctions.bessel(false, 3, 0.20000000000000000000), 1E-13);
+
+        assertEquals(4.158340274471933E-6, SpecialFunctions.bessel(false, 4, 0.20000000000000000000), 1E-13);
+
+        assertEquals(8.319454360946915E-8, SpecialFunctions.bessel(false, 5, 0.20000000000000000000), 1E-13);
+
+        assertEquals(0.1960265779553187, SpecialFunctions.bessel(false, 1, 0.40000000000000000000), 1E-13);
+
+        assertEquals(0.01973466311703027, SpecialFunctions.bessel(false, 2, 0.40000000000000000000), 1E-13);
+
+        assertEquals(0.001320053214983958, SpecialFunctions.bessel(false, 3, 0.40000000000000000000), 1E-13);
+
+        assertEquals(0.00006613510772909677, SpecialFunctions.bessel(false, 4, 0.40000000000000000000), 1E-13);
+
+        assertEquals(2.648939597977585E-6, SpecialFunctions.bessel(false, 5, 0.40000000000000000000), 1E-13);
+
+        assertEquals(0.2867009880639157, SpecialFunctions.bessel(false, 1, 0.60000000000000000000), 1E-13);
+
+        assertEquals(0.04366509671584169, SpecialFunctions.bessel(false, 2, 0.60000000000000000000), 1E-13);
+
+        assertEquals(0.004399656708362193, SpecialFunctions.bessel(false, 3, 0.60000000000000000000), 1E-13);
+
+        assertEquals(0.0003314703677802370, SpecialFunctions.bessel(false, 4, 0.60000000000000000000), 1E-13);
+
+        assertEquals(0.00001994819537430024, SpecialFunctions.bessel(false, 5, 0.60000000000000000000), 1E-13);
+
+        assertEquals(0.3688420460941700, SpecialFunctions.bessel(false, 1, 0.80000000000000000000), 1E-13);
+
+        assertEquals(0.07581776248494472, SpecialFunctions.bessel(false, 2, 0.80000000000000000000), 1E-13);
+
+        assertEquals(0.01024676633055360, SpecialFunctions.bessel(false, 3, 0.80000000000000000000), 1E-13);
+
+        assertEquals(0.001032984994207302, SpecialFunctions.bessel(false, 4, 0.80000000000000000000), 1E-13);
+
+        assertEquals(0.00008308361151942143, SpecialFunctions.bessel(false, 5, 0.80000000000000000000), 1E-13);
+
+        assertEquals(0.4400505857449335, SpecialFunctions.bessel(false, 1, 1.0000000000000000000), 1E-13);
+
+        assertEquals(0.1149034849319005, SpecialFunctions.bessel(false, 2, 1.0000000000000000000), 1E-13);
+
+        assertEquals(0.01956335398266841, SpecialFunctions.bessel(false, 3, 1.0000000000000000000), 1E-13);
+
+        assertEquals(0.002476638964109955, SpecialFunctions.bessel(false, 4, 1.0000000000000000000), 1E-13);
+
+        assertEquals(0.0002497577302112344, SpecialFunctions.bessel(false, 5, 1.0000000000000000000), 1E-13);
+
+        assertEquals(0.4982890575672155, SpecialFunctions.bessel(false, 1, 1.2000000000000000000), 1E-13);
+
+        assertEquals(0.1593490183476631, SpecialFunctions.bessel(false, 2, 1.2000000000000000000), 1E-13);
+
+        assertEquals(0.03287433692499494, SpecialFunctions.bessel(false, 3, 1.2000000000000000000), 1E-13);
+
+        assertEquals(0.005022666277311587, SpecialFunctions.bessel(false, 4, 1.2000000000000000000), 1E-13);
+
+        assertEquals(0.0006101049237489684, SpecialFunctions.bessel(false, 5, 1.2000000000000000000), 1E-13);
+
+        assertEquals(0.5419477139308545, SpecialFunctions.bessel(false, 1, 1.4000000000000000000), 1E-13);
+
+        assertEquals(0.2073558995269320, SpecialFunctions.bessel(false, 2, 1.4000000000000000000), 1E-13);
+
+        assertEquals(0.05049771328895130, SpecialFunctions.bessel(false, 3, 1.4000000000000000000), 1E-13);
+
+        assertEquals(0.009062871711430658, SpecialFunctions.bessel(false, 4, 1.4000000000000000000), 1E-13);
+
+        assertEquals(0.001290125062081034, SpecialFunctions.bessel(false, 5, 1.4000000000000000000), 1E-13);
+
+        assertEquals(0.5698959352616804, SpecialFunctions.bessel(false, 1, 1.6000000000000000000), 1E-13);
+
+        assertEquals(0.2569677514377197, SpecialFunctions.bessel(false, 2, 1.6000000000000000000), 1E-13);
+
+        assertEquals(0.07252344333261900, SpecialFunctions.bessel(false, 3, 1.6000000000000000000), 1E-13);
+
+        assertEquals(0.01499516105960151, SpecialFunctions.bessel(false, 4, 1.6000000000000000000), 1E-13);
+
+        assertEquals(0.002452361965388557, SpecialFunctions.bessel(false, 5, 1.6000000000000000000), 1E-13);
+
+        assertEquals(0.5815169517311652, SpecialFunctions.bessel(false, 1, 1.8000000000000000000), 1E-13);
+
+        assertEquals(0.3061435353254030, SpecialFunctions.bessel(false, 2, 1.8000000000000000000), 1E-13);
+
+        assertEquals(0.09880201565861918, SpecialFunctions.bessel(false, 3, 1.8000000000000000000), 1E-13);
+
+        assertEquals(0.02319651686999431, SpecialFunctions.bessel(false, 4, 1.8000000000000000000), 1E-13);
+
+        assertEquals(0.004293614874688868, SpecialFunctions.bessel(false, 5, 1.8000000000000000000), 1E-13);
+
+        assertEquals(0.5767248077568734, SpecialFunctions.bessel(false, 1, 2.0000000000000000000), 1E-13);
+
+        assertEquals(0.3528340286156377, SpecialFunctions.bessel(false, 2, 2.0000000000000000000), 1E-13);
+
+        assertEquals(0.1289432494744021, SpecialFunctions.bessel(false, 3, 2.0000000000000000000), 1E-13);
+
+        assertEquals(0.03399571980756843, SpecialFunctions.bessel(false, 4, 2.0000000000000000000), 1E-13);
+
+        assertEquals(0.007039629755871685, SpecialFunctions.bessel(false, 5, 2.0000000000000000000), 1E-13);
+
+        assertEquals(0.5559630498190639, SpecialFunctions.bessel(false, 1, 2.2000000000000000000), 1E-13);
+
+        assertEquals(0.3950586874587933, SpecialFunctions.bessel(false, 2, 2.2000000000000000000), 1E-13);
+
+        assertEquals(0.1623254728332875, SpecialFunctions.bessel(false, 3, 2.2000000000000000000), 1E-13);
+
+        assertEquals(0.04764714754108161, SpecialFunctions.bessel(false, 4, 2.2000000000000000000), 1E-13);
+
+        assertEquals(0.01093688186155476, SpecialFunctions.bessel(false, 5, 2.2000000000000000000), 1E-13);
+
+        assertEquals(0.5201852681819310, SpecialFunctions.bessel(false, 1, 2.4000000000000000000), 1E-13);
+
+        assertEquals(0.4309800401876987, SpecialFunctions.bessel(false, 2, 2.4000000000000000000), 1E-13);
+
+        assertEquals(0.1981147987975668, SpecialFunctions.bessel(false, 3, 2.4000000000000000000), 1E-13);
+
+        assertEquals(0.06430695680621835, SpecialFunctions.bessel(false, 4, 2.4000000000000000000), 1E-13);
+
+        assertEquals(0.01624172388982766, SpecialFunctions.bessel(false, 5, 2.4000000000000000000), 1E-13);
+
+        assertEquals(0.4708182665175787, SpecialFunctions.bessel(false, 1, 2.6000000000000000000), 1E-13);
+
+        assertEquals(0.4589728517182526, SpecialFunctions.bessel(false, 2, 2.6000000000000000000), 1E-13);
+
+        assertEquals(0.2352938130489638, SpecialFunctions.bessel(false, 3, 2.6000000000000000000), 1E-13);
+
+        assertEquals(0.08401287070243310, SpecialFunctions.bessel(false, 4, 2.6000000000000000000), 1E-13);
+
+        assertEquals(0.02320732757390727, SpecialFunctions.bessel(false, 5, 2.6000000000000000000), 1E-13);
+
+        assertEquals(0.4097092468522887, SpecialFunctions.bessel(false, 1, 2.8000000000000000000), 1E-13);
+
+        assertEquals(0.4776854954017364, SpecialFunctions.bessel(false, 2, 2.8000000000000000000), 1E-13);
+
+        assertEquals(0.2726986037216204, SpecialFunctions.bessel(false, 3, 2.8000000000000000000), 1E-13);
+
+        assertEquals(0.1066686554303074, SpecialFunctions.bessel(false, 4, 2.8000000000000000000), 1E-13);
+
+        assertEquals(0.03206898322211490, SpecialFunctions.bessel(false, 5, 2.8000000000000000000), 1E-13);
+
+        assertEquals(0.3390589585259365, SpecialFunctions.bessel(false, 1, 3.0000000000000000000), 1E-13);
+
+        assertEquals(0.4860912605858911, SpecialFunctions.bessel(false, 2, 3.0000000000000000000), 1E-13);
+
+        assertEquals(0.3090627222552516, SpecialFunctions.bessel(false, 3, 3.0000000000000000000), 1E-13);
+
+        assertEquals(0.1320341839246122, SpecialFunctions.bessel(false, 4, 3.0000000000000000000), 1E-13);
+
+        assertEquals(0.04302843487704758, SpecialFunctions.bessel(false, 5, 3.0000000000000000000), 1E-13);
+
+        assertEquals(0.2613432487805048, SpecialFunctions.bessel(false, 1, 3.2000000000000000000), 1E-13);
+
+        assertEquals(0.4835277001449384, SpecialFunctions.bessel(false, 2, 3.2000000000000000000), 1E-13);
+
+        assertEquals(0.3430663764006682, SpecialFunctions.bessel(false, 3, 3.2000000000000000000), 1E-13);
+
+        assertEquals(0.1597217556063144, SpecialFunctions.bessel(false, 4, 3.2000000000000000000), 1E-13);
+
+        assertEquals(0.05623801261511791, SpecialFunctions.bessel(false, 5, 3.2000000000000000000), 1E-13);
+
+        assertEquals(0.1792258516815071, SpecialFunctions.bessel(false, 1, 3.4000000000000000000), 1E-13);
+
+        assertEquals(0.4697225683393576, SpecialFunctions.bessel(false, 2, 3.4000000000000000000), 1E-13);
+
+        assertEquals(0.3733889346000901, SpecialFunctions.bessel(false, 3, 3.4000000000000000000), 1E-13);
+
+        assertEquals(0.1891990809549190, SpecialFunctions.bessel(false, 4, 3.4000000000000000000), 1E-13);
+
+        assertEquals(0.07178537352913107, SpecialFunctions.bessel(false, 5, 3.4000000000000000000), 1E-13);
+
+        assertEquals(0.09546554717787640, SpecialFunctions.bessel(false, 1, 3.6000000000000000000), 1E-13);
+
+        assertEquals(0.4448053987996180, SpecialFunctions.bessel(false, 2, 3.6000000000000000000), 1E-13);
+
+        assertEquals(0.3987626737105880, SpecialFunctions.bessel(false, 3, 3.6000000000000000000), 1E-13);
+
+        assertEquals(0.2197990573846954, SpecialFunctions.bessel(false, 4, 3.6000000000000000000), 1E-13);
+
+        assertEquals(0.08967967603317951, SpecialFunctions.bessel(false, 5, 3.6000000000000000000), 1E-13);
+
+        assertEquals(0.01282100292673163, SpecialFunctions.bessel(false, 1, 3.8000000000000000000), 1E-13);
+
+        assertEquals(0.4093043064557913, SpecialFunctions.bessel(false, 2, 3.8000000000000000000), 1E-13);
+
+        assertEquals(0.4180256354477856, SpecialFunctions.bessel(false, 3, 3.8000000000000000000), 1E-13);
+
+        assertEquals(0.2507361705670280, SpecialFunctions.bessel(false, 4, 3.8000000000000000000), 1E-13);
+
+        assertEquals(0.1098399867985891, SpecialFunctions.bessel(false, 5, 3.8000000000000000000), 1E-13);
+
+        assertEquals(-0.06604332802354914, SpecialFunctions.bessel(false, 1, 4.0000000000000000000), 1E-13);
+
+        assertEquals(0.3641281458520728, SpecialFunctions.bessel(false, 2, 4.0000000000000000000), 1E-13);
+
+        assertEquals(0.4301714738756219, SpecialFunctions.bessel(false, 3, 4.0000000000000000000), 1E-13);
+
+        assertEquals(0.2811290649613601, SpecialFunctions.bessel(false, 4, 4.0000000000000000000), 1E-13);
+
+        assertEquals(0.1320866560470983, SpecialFunctions.bessel(false, 5, 4.0000000000000000000), 1E-13);
+
+        assertEquals(-0.1386469421260462, SpecialFunctions.bessel(false, 1, 4.2000000000000000000), 1E-13);
+
+        assertEquals(0.3105347009742123, SpecialFunctions.bessel(false, 2, 4.2000000000000000000), 1E-13);
+
+        assertEquals(0.4343942763872008, SpecialFunctions.bessel(false, 3, 4.2000000000000000000), 1E-13);
+
+        assertEquals(0.3100285510075031, SpecialFunctions.bessel(false, 4, 4.2000000000000000000), 1E-13);
+
+        assertEquals(0.1561362969604241, SpecialFunctions.bessel(false, 5, 4.2000000000000000000), 1E-13);
+
+        assertEquals(-0.2027755219230866, SpecialFunctions.bessel(false, 1, 4.4000000000000000000), 1E-13);
+
+        assertEquals(0.2500860982206644, SpecialFunctions.bessel(false, 2, 4.4000000000000000000), 1E-13);
+
+        assertEquals(0.4301265203055088, SpecialFunctions.bessel(false, 3, 4.4000000000000000000), 1E-13);
+
+        assertEquals(0.3364500658323021, SpecialFunctions.bessel(false, 4, 4.4000000000000000000), 1E-13);
+
+        assertEquals(0.1816008721168587, SpecialFunctions.bessel(false, 5, 4.4000000000000000000), 1E-13);
+
+        assertEquals(-0.2565528360974446, SpecialFunctions.bessel(false, 1, 4.6000000000000000000), 1E-13);
+
+        assertEquals(0.1845931052274261, SpecialFunctions.bessel(false, 2, 4.6000000000000000000), 1E-13);
+
+        assertEquals(0.4170685797734673, SpecialFunctions.bessel(false, 3, 4.6000000000000000000), 1E-13);
+
+        assertEquals(0.3594093901292703, SpecialFunctions.bessel(false, 4, 4.6000000000000000000), 1E-13);
+
+        assertEquals(0.2079912291470029, SpecialFunctions.bessel(false, 5, 4.6000000000000000000), 1E-13);
+
+        assertEquals(-0.2984998580995579, SpecialFunctions.bessel(false, 1, 4.8000000000000000000), 1E-13);
+
+        assertEquals(0.1160503864163677, SpecialFunctions.bessel(false, 2, 4.8000000000000000000), 1E-13);
+
+        assertEquals(0.3952085134465309, SpecialFunctions.bessel(false, 3, 4.8000000000000000000), 1E-13);
+
+        assertEquals(0.3779602553917960, SpecialFunctions.bessel(false, 4, 4.8000000000000000000), 1E-13);
+
+        assertEquals(0.2347252455397957, SpecialFunctions.bessel(false, 5, 4.8000000000000000000), 1E-13);
+
+        assertEquals(-0.3275791375914652, SpecialFunctions.bessel(false, 1, 5.0000000000000000000), 1E-13);
+
+        assertEquals(0.04656511627775222, SpecialFunctions.bessel(false, 2, 5.0000000000000000000), 1E-13);
+
+        assertEquals(0.3648312306136670, SpecialFunctions.bessel(false, 3, 5.0000000000000000000), 1E-13);
+
+        assertEquals(0.3912323604586482, SpecialFunctions.bessel(false, 4, 5.0000000000000000000), 1E-13);
+
+        assertEquals(0.2611405461201701, SpecialFunctions.bessel(false, 5, 5.0000000000000000000), 1E-13);
+
+        assertEquals(-0.3432230058719219, SpecialFunctions.bessel(false, 1, 5.2000000000000000000), 1E-13);
+
+        assertEquals(-0.02171840862129112, SpecialFunctions.bessel(false, 2, 5.2000000000000000000), 1E-13);
+
+        assertEquals(0.3265165377016980, SpecialFunctions.bessel(false, 3, 5.2000000000000000000), 1E-13);
+
+        assertEquals(0.3984682598155580, SpecialFunctions.bessel(false, 4, 5.2000000000000000000), 1E-13);
+
+        assertEquals(0.2865115543222374, SpecialFunctions.bessel(false, 5, 5.2000000000000000000), 1E-13);
+
+        assertEquals(-0.3453447907795863, SpecialFunctions.bessel(false, 1, 5.4000000000000000000), 1E-13);
+
+        assertEquals(-0.08669537682152215, SpecialFunctions.bessel(false, 2, 5.4000000000000000000), 1E-13);
+
+        assertEquals(0.2811259931340144, SpecialFunctions.bessel(false, 3, 5.4000000000000000000), 1E-13);
+
+        assertEquals(0.3990575914148714, SpecialFunctions.bessel(false, 4, 5.4000000000000000000), 1E-13);
+
+        assertEquals(0.3100704385917211, SpecialFunctions.bessel(false, 5, 5.4000000000000000000), 1E-13);
+
+        assertEquals(-0.3343328362910075, SpecialFunctions.bessel(false, 1, 5.6000000000000000000), 1E-13);
+
+        assertEquals(-0.1463754690747600, SpecialFunctions.bessel(false, 2, 5.6000000000000000000), 1E-13);
+
+        assertEquals(0.2297789298090361, SpecialFunctions.bessel(false, 3, 5.6000000000000000000), 1E-13);
+
+        assertEquals(0.3925671795844415, SpecialFunctions.bessel(false, 4, 5.6000000000000000000), 1E-13);
+
+        assertEquals(0.3310313267401661, SpecialFunctions.bessel(false, 5, 5.6000000000000000000), 1E-13);
+
+        assertEquals(-0.3110277443039424, SpecialFunctions.bessel(false, 1, 5.8000000000000000000), 1E-13);
+
+        assertEquals(-0.1989535138865205, SpecialFunctions.bessel(false, 2, 5.8000000000000000000), 1E-13);
+
+        assertEquals(0.1738184243822042, SpecialFunctions.bessel(false, 3, 5.8000000000000000000), 1E-13);
+
+        assertEquals(0.3787656770405248, SpecialFunctions.bessel(false, 4, 5.8000000000000000000), 1E-13);
+
+        assertEquals(0.3486169922254162, SpecialFunctions.bessel(false, 5, 5.8000000000000000000), 1E-13);
+
+        assertEquals(-0.2766838581275656, SpecialFunctions.bessel(false, 1, 6.0000000000000000000), 1E-13);
+
+        assertEquals(-0.2428732099601855, SpecialFunctions.bessel(false, 2, 6.0000000000000000000), 1E-13);
+
+        assertEquals(0.1147683848207753, SpecialFunctions.bessel(false, 3, 6.0000000000000000000), 1E-13);
+
+        assertEquals(0.3576415947809608, SpecialFunctions.bessel(false, 4, 6.0000000000000000000), 1E-13);
+
+        assertEquals(0.3620870748871724, SpecialFunctions.bessel(false, 5, 6.0000000000000000000), 1E-13);
+
     }
 
-    @Test
-    public void testBesselJ() throws Exception {
-        assertEquals(0.09950083263923600,SpecialFunctions.besselJ(1,0.20000000000000000000),1E-13);
-
-        assertEquals(0.004983354152783563,SpecialFunctions.besselJ(2,0.20000000000000000000),1E-13);
-
-        assertEquals(0.0001662504164352678,SpecialFunctions.besselJ(3,0.20000000000000000000),1E-13);
-
-        assertEquals(4.158340274471933E-6,SpecialFunctions.besselJ(4,0.20000000000000000000),1E-13);
-
-        assertEquals(8.319454360946915E-8,SpecialFunctions.besselJ(5,0.20000000000000000000),1E-13);
-
-        assertEquals(0.1960265779553187,SpecialFunctions.besselJ(1,0.40000000000000000000),1E-13);
-
-        assertEquals(0.01973466311703027,SpecialFunctions.besselJ(2,0.40000000000000000000),1E-13);
-
-        assertEquals(0.001320053214983958,SpecialFunctions.besselJ(3,0.40000000000000000000),1E-13);
-
-        assertEquals(0.00006613510772909677,SpecialFunctions.besselJ(4,0.40000000000000000000),1E-13);
-
-        assertEquals(2.648939597977585E-6,SpecialFunctions.besselJ(5,0.40000000000000000000),1E-13);
-
-        assertEquals(0.2867009880639157,SpecialFunctions.besselJ(1,0.60000000000000000000),1E-13);
-
-        assertEquals(0.04366509671584169,SpecialFunctions.besselJ(2,0.60000000000000000000),1E-13);
-
-        assertEquals(0.004399656708362193,SpecialFunctions.besselJ(3,0.60000000000000000000),1E-13);
-
-        assertEquals(0.0003314703677802370,SpecialFunctions.besselJ(4,0.60000000000000000000),1E-13);
-
-        assertEquals(0.00001994819537430024,SpecialFunctions.besselJ(5,0.60000000000000000000),1E-13);
-
-        assertEquals(0.3688420460941700,SpecialFunctions.besselJ(1,0.80000000000000000000),1E-13);
-
-        assertEquals(0.07581776248494472,SpecialFunctions.besselJ(2,0.80000000000000000000),1E-13);
-
-        assertEquals(0.01024676633055360,SpecialFunctions.besselJ(3,0.80000000000000000000),1E-13);
-
-        assertEquals(0.001032984994207302,SpecialFunctions.besselJ(4,0.80000000000000000000),1E-13);
-
-        assertEquals(0.00008308361151942143,SpecialFunctions.besselJ(5,0.80000000000000000000),1E-13);
-
-        assertEquals(0.4400505857449335,SpecialFunctions.besselJ(1,1.0000000000000000000),1E-13);
-
-        assertEquals(0.1149034849319005,SpecialFunctions.besselJ(2,1.0000000000000000000),1E-13);
-
-        assertEquals(0.01956335398266841,SpecialFunctions.besselJ(3,1.0000000000000000000),1E-13);
-
-        assertEquals(0.002476638964109955,SpecialFunctions.besselJ(4,1.0000000000000000000),1E-13);
-
-        assertEquals(0.0002497577302112344,SpecialFunctions.besselJ(5,1.0000000000000000000),1E-13);
-
-        assertEquals(0.4982890575672155,SpecialFunctions.besselJ(1,1.2000000000000000000),1E-13);
-
-        assertEquals(0.1593490183476631,SpecialFunctions.besselJ(2,1.2000000000000000000),1E-13);
-
-        assertEquals(0.03287433692499494,SpecialFunctions.besselJ(3,1.2000000000000000000),1E-13);
-
-        assertEquals(0.005022666277311587,SpecialFunctions.besselJ(4,1.2000000000000000000),1E-13);
-
-        assertEquals(0.0006101049237489684,SpecialFunctions.besselJ(5,1.2000000000000000000),1E-13);
-
-        assertEquals(0.5419477139308545,SpecialFunctions.besselJ(1,1.4000000000000000000),1E-13);
-
-        assertEquals(0.2073558995269320,SpecialFunctions.besselJ(2,1.4000000000000000000),1E-13);
-
-        assertEquals(0.05049771328895130,SpecialFunctions.besselJ(3,1.4000000000000000000),1E-13);
-
-        assertEquals(0.009062871711430658,SpecialFunctions.besselJ(4,1.4000000000000000000),1E-13);
-
-        assertEquals(0.001290125062081034,SpecialFunctions.besselJ(5,1.4000000000000000000),1E-13);
-
-        assertEquals(0.5698959352616804,SpecialFunctions.besselJ(1,1.6000000000000000000),1E-13);
-
-        assertEquals(0.2569677514377197,SpecialFunctions.besselJ(2,1.6000000000000000000),1E-13);
-
-        assertEquals(0.07252344333261900,SpecialFunctions.besselJ(3,1.6000000000000000000),1E-13);
-
-        assertEquals(0.01499516105960151,SpecialFunctions.besselJ(4,1.6000000000000000000),1E-13);
-
-        assertEquals(0.002452361965388557,SpecialFunctions.besselJ(5,1.6000000000000000000),1E-13);
-
-        assertEquals(0.5815169517311652,SpecialFunctions.besselJ(1,1.8000000000000000000),1E-13);
-
-        assertEquals(0.3061435353254030,SpecialFunctions.besselJ(2,1.8000000000000000000),1E-13);
-
-        assertEquals(0.09880201565861918,SpecialFunctions.besselJ(3,1.8000000000000000000),1E-13);
-
-        assertEquals(0.02319651686999431,SpecialFunctions.besselJ(4,1.8000000000000000000),1E-13);
-
-        assertEquals(0.004293614874688868,SpecialFunctions.besselJ(5,1.8000000000000000000),1E-13);
-
-        assertEquals(0.5767248077568734,SpecialFunctions.besselJ(1,2.0000000000000000000),1E-13);
-
-        assertEquals(0.3528340286156377,SpecialFunctions.besselJ(2,2.0000000000000000000),1E-13);
-
-        assertEquals(0.1289432494744021,SpecialFunctions.besselJ(3,2.0000000000000000000),1E-13);
-
-        assertEquals(0.03399571980756843,SpecialFunctions.besselJ(4,2.0000000000000000000),1E-13);
-
-        assertEquals(0.007039629755871685,SpecialFunctions.besselJ(5,2.0000000000000000000),1E-13);
-
-        assertEquals(0.5559630498190639,SpecialFunctions.besselJ(1,2.2000000000000000000),1E-13);
-
-        assertEquals(0.3950586874587933,SpecialFunctions.besselJ(2,2.2000000000000000000),1E-13);
-
-        assertEquals(0.1623254728332875,SpecialFunctions.besselJ(3,2.2000000000000000000),1E-13);
-
-        assertEquals(0.04764714754108161,SpecialFunctions.besselJ(4,2.2000000000000000000),1E-13);
-
-        assertEquals(0.01093688186155476,SpecialFunctions.besselJ(5,2.2000000000000000000),1E-13);
-
-        assertEquals(0.5201852681819310,SpecialFunctions.besselJ(1,2.4000000000000000000),1E-13);
-
-        assertEquals(0.4309800401876987,SpecialFunctions.besselJ(2,2.4000000000000000000),1E-13);
-
-        assertEquals(0.1981147987975668,SpecialFunctions.besselJ(3,2.4000000000000000000),1E-13);
-
-        assertEquals(0.06430695680621835,SpecialFunctions.besselJ(4,2.4000000000000000000),1E-13);
-
-        assertEquals(0.01624172388982766,SpecialFunctions.besselJ(5,2.4000000000000000000),1E-13);
-
-        assertEquals(0.4708182665175787,SpecialFunctions.besselJ(1,2.6000000000000000000),1E-13);
-
-        assertEquals(0.4589728517182526,SpecialFunctions.besselJ(2,2.6000000000000000000),1E-13);
-
-        assertEquals(0.2352938130489638,SpecialFunctions.besselJ(3,2.6000000000000000000),1E-13);
-
-        assertEquals(0.08401287070243310,SpecialFunctions.besselJ(4,2.6000000000000000000),1E-13);
-
-        assertEquals(0.02320732757390727,SpecialFunctions.besselJ(5,2.6000000000000000000),1E-13);
-
-        assertEquals(0.4097092468522887,SpecialFunctions.besselJ(1,2.8000000000000000000),1E-13);
-
-        assertEquals(0.4776854954017364,SpecialFunctions.besselJ(2,2.8000000000000000000),1E-13);
-
-        assertEquals(0.2726986037216204,SpecialFunctions.besselJ(3,2.8000000000000000000),1E-13);
-
-        assertEquals(0.1066686554303074,SpecialFunctions.besselJ(4,2.8000000000000000000),1E-13);
-
-        assertEquals(0.03206898322211490,SpecialFunctions.besselJ(5,2.8000000000000000000),1E-13);
-
-        assertEquals(0.3390589585259365,SpecialFunctions.besselJ(1,3.0000000000000000000),1E-13);
-
-        assertEquals(0.4860912605858911,SpecialFunctions.besselJ(2,3.0000000000000000000),1E-13);
-
-        assertEquals(0.3090627222552516,SpecialFunctions.besselJ(3,3.0000000000000000000),1E-13);
-
-        assertEquals(0.1320341839246122,SpecialFunctions.besselJ(4,3.0000000000000000000),1E-13);
-
-        assertEquals(0.04302843487704758,SpecialFunctions.besselJ(5,3.0000000000000000000),1E-13);
-
-        assertEquals(0.2613432487805048,SpecialFunctions.besselJ(1,3.2000000000000000000),1E-13);
-
-        assertEquals(0.4835277001449384,SpecialFunctions.besselJ(2,3.2000000000000000000),1E-13);
-
-        assertEquals(0.3430663764006682,SpecialFunctions.besselJ(3,3.2000000000000000000),1E-13);
-
-        assertEquals(0.1597217556063144,SpecialFunctions.besselJ(4,3.2000000000000000000),1E-13);
-
-        assertEquals(0.05623801261511791,SpecialFunctions.besselJ(5,3.2000000000000000000),1E-13);
-
-        assertEquals(0.1792258516815071,SpecialFunctions.besselJ(1,3.4000000000000000000),1E-13);
-
-        assertEquals(0.4697225683393576,SpecialFunctions.besselJ(2,3.4000000000000000000),1E-13);
-
-        assertEquals(0.3733889346000901,SpecialFunctions.besselJ(3,3.4000000000000000000),1E-13);
-
-        assertEquals(0.1891990809549190,SpecialFunctions.besselJ(4,3.4000000000000000000),1E-13);
-
-        assertEquals(0.07178537352913107,SpecialFunctions.besselJ(5,3.4000000000000000000),1E-13);
-
-        assertEquals(0.09546554717787640,SpecialFunctions.besselJ(1,3.6000000000000000000),1E-13);
-
-        assertEquals(0.4448053987996180,SpecialFunctions.besselJ(2,3.6000000000000000000),1E-13);
-
-        assertEquals(0.3987626737105880,SpecialFunctions.besselJ(3,3.6000000000000000000),1E-13);
-
-        assertEquals(0.2197990573846954,SpecialFunctions.besselJ(4,3.6000000000000000000),1E-13);
-
-        assertEquals(0.08967967603317951,SpecialFunctions.besselJ(5,3.6000000000000000000),1E-13);
-
-        assertEquals(0.01282100292673163,SpecialFunctions.besselJ(1,3.8000000000000000000),1E-13);
-
-        assertEquals(0.4093043064557913,SpecialFunctions.besselJ(2,3.8000000000000000000),1E-13);
-
-        assertEquals(0.4180256354477856,SpecialFunctions.besselJ(3,3.8000000000000000000),1E-13);
-
-        assertEquals(0.2507361705670280,SpecialFunctions.besselJ(4,3.8000000000000000000),1E-13);
-
-        assertEquals(0.1098399867985891,SpecialFunctions.besselJ(5,3.8000000000000000000),1E-13);
-
-        assertEquals(-0.06604332802354914,SpecialFunctions.besselJ(1,4.0000000000000000000),1E-13);
-
-        assertEquals(0.3641281458520728,SpecialFunctions.besselJ(2,4.0000000000000000000),1E-13);
-
-        assertEquals(0.4301714738756219,SpecialFunctions.besselJ(3,4.0000000000000000000),1E-13);
-
-        assertEquals(0.2811290649613601,SpecialFunctions.besselJ(4,4.0000000000000000000),1E-13);
-
-        assertEquals(0.1320866560470983,SpecialFunctions.besselJ(5,4.0000000000000000000),1E-13);
-
-        assertEquals(-0.1386469421260462,SpecialFunctions.besselJ(1,4.2000000000000000000),1E-13);
-
-        assertEquals(0.3105347009742123,SpecialFunctions.besselJ(2,4.2000000000000000000),1E-13);
-
-        assertEquals(0.4343942763872008,SpecialFunctions.besselJ(3,4.2000000000000000000),1E-13);
-
-        assertEquals(0.3100285510075031,SpecialFunctions.besselJ(4,4.2000000000000000000),1E-13);
-
-        assertEquals(0.1561362969604241,SpecialFunctions.besselJ(5,4.2000000000000000000),1E-13);
-
-        assertEquals(-0.2027755219230866,SpecialFunctions.besselJ(1,4.4000000000000000000),1E-13);
-
-        assertEquals(0.2500860982206644,SpecialFunctions.besselJ(2,4.4000000000000000000),1E-13);
-
-        assertEquals(0.4301265203055088,SpecialFunctions.besselJ(3,4.4000000000000000000),1E-13);
-
-        assertEquals(0.3364500658323021,SpecialFunctions.besselJ(4,4.4000000000000000000),1E-13);
-
-        assertEquals(0.1816008721168587,SpecialFunctions.besselJ(5,4.4000000000000000000),1E-13);
-
-        assertEquals(-0.2565528360974446,SpecialFunctions.besselJ(1,4.6000000000000000000),1E-13);
-
-        assertEquals(0.1845931052274261,SpecialFunctions.besselJ(2,4.6000000000000000000),1E-13);
-
-        assertEquals(0.4170685797734673,SpecialFunctions.besselJ(3,4.6000000000000000000),1E-13);
-
-        assertEquals(0.3594093901292703,SpecialFunctions.besselJ(4,4.6000000000000000000),1E-13);
-
-        assertEquals(0.2079912291470029,SpecialFunctions.besselJ(5,4.6000000000000000000),1E-13);
-
-        assertEquals(-0.2984998580995579,SpecialFunctions.besselJ(1,4.8000000000000000000),1E-13);
-
-        assertEquals(0.1160503864163677,SpecialFunctions.besselJ(2,4.8000000000000000000),1E-13);
-
-        assertEquals(0.3952085134465309,SpecialFunctions.besselJ(3,4.8000000000000000000),1E-13);
-
-        assertEquals(0.3779602553917960,SpecialFunctions.besselJ(4,4.8000000000000000000),1E-13);
-
-        assertEquals(0.2347252455397957,SpecialFunctions.besselJ(5,4.8000000000000000000),1E-13);
-
-        assertEquals(-0.3275791375914652,SpecialFunctions.besselJ(1,5.0000000000000000000),1E-13);
-
-        assertEquals(0.04656511627775222,SpecialFunctions.besselJ(2,5.0000000000000000000),1E-13);
-
-        assertEquals(0.3648312306136670,SpecialFunctions.besselJ(3,5.0000000000000000000),1E-13);
-
-        assertEquals(0.3912323604586482,SpecialFunctions.besselJ(4,5.0000000000000000000),1E-13);
-
-        assertEquals(0.2611405461201701,SpecialFunctions.besselJ(5,5.0000000000000000000),1E-13);
-
-        assertEquals(-0.3432230058719219,SpecialFunctions.besselJ(1,5.2000000000000000000),1E-13);
-
-        assertEquals(-0.02171840862129112,SpecialFunctions.besselJ(2,5.2000000000000000000),1E-13);
-
-        assertEquals(0.3265165377016980,SpecialFunctions.besselJ(3,5.2000000000000000000),1E-13);
-
-        assertEquals(0.3984682598155580,SpecialFunctions.besselJ(4,5.2000000000000000000),1E-13);
-
-        assertEquals(0.2865115543222374,SpecialFunctions.besselJ(5,5.2000000000000000000),1E-13);
-
-        assertEquals(-0.3453447907795863,SpecialFunctions.besselJ(1,5.4000000000000000000),1E-13);
-
-        assertEquals(-0.08669537682152215,SpecialFunctions.besselJ(2,5.4000000000000000000),1E-13);
-
-        assertEquals(0.2811259931340144,SpecialFunctions.besselJ(3,5.4000000000000000000),1E-13);
-
-        assertEquals(0.3990575914148714,SpecialFunctions.besselJ(4,5.4000000000000000000),1E-13);
-
-        assertEquals(0.3100704385917211,SpecialFunctions.besselJ(5,5.4000000000000000000),1E-13);
-
-        assertEquals(-0.3343328362910075,SpecialFunctions.besselJ(1,5.6000000000000000000),1E-13);
-
-        assertEquals(-0.1463754690747600,SpecialFunctions.besselJ(2,5.6000000000000000000),1E-13);
-
-        assertEquals(0.2297789298090361,SpecialFunctions.besselJ(3,5.6000000000000000000),1E-13);
-
-        assertEquals(0.3925671795844415,SpecialFunctions.besselJ(4,5.6000000000000000000),1E-13);
-
-        assertEquals(0.3310313267401661,SpecialFunctions.besselJ(5,5.6000000000000000000),1E-13);
-
-        assertEquals(-0.3110277443039424,SpecialFunctions.besselJ(1,5.8000000000000000000),1E-13);
-
-        assertEquals(-0.1989535138865205,SpecialFunctions.besselJ(2,5.8000000000000000000),1E-13);
-
-        assertEquals(0.1738184243822042,SpecialFunctions.besselJ(3,5.8000000000000000000),1E-13);
-
-        assertEquals(0.3787656770405248,SpecialFunctions.besselJ(4,5.8000000000000000000),1E-13);
-
-        assertEquals(0.3486169922254162,SpecialFunctions.besselJ(5,5.8000000000000000000),1E-13);
-
-        assertEquals(-0.2766838581275656,SpecialFunctions.besselJ(1,6.0000000000000000000),1E-13);
-
-        assertEquals(-0.2428732099601855,SpecialFunctions.besselJ(2,6.0000000000000000000),1E-13);
-
-        assertEquals(0.1147683848207753,SpecialFunctions.besselJ(3,6.0000000000000000000),1E-13);
-
-        assertEquals(0.3576415947809608,SpecialFunctions.besselJ(4,6.0000000000000000000),1E-13);
-
-        assertEquals(0.3620870748871724,SpecialFunctions.besselJ(5,6.0000000000000000000),1E-13);
-
-    }
 
     @Test
     public void testFactorial() {

--- a/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
+++ b/etomica-core/src/test/java/etomica/math/SpecialFunctionsTest.java
@@ -10,6 +10,9 @@ import static org.junit.Assert.assertEquals;
  * Created by alex on 4/24/17.
  */
 public class SpecialFunctionsTest {
+    private static final double EPSILON = 1e-10;
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
     private double epislon = 1E-7;
 
     @Test
@@ -19,7 +22,6 @@ public class SpecialFunctionsTest {
         }
 
     }
-
 
     @Test
     public void testLnGamma() throws Exception {
@@ -34,6 +36,13 @@ public class SpecialFunctionsTest {
 
     @Test
     public void testGamma() throws Exception {
+        for (double x = 0.1; x < 10.01; x += 0.1) {
+            if (Math.abs(SpecialFunctions.gamma(x)) < 1.0) {
+                assertEquals(org.apache.commons.math3.special.Gamma.gamma(x), SpecialFunctions.gamma(x), 1E-14);
+            } else {
+                assertEquals(1.0, org.apache.commons.math3.special.Gamma.gamma(x) / SpecialFunctions.gamma(x), 1E-14);
+            }
+        }
     }
 
     @Test
@@ -42,29 +51,796 @@ public class SpecialFunctionsTest {
 
     @Test
     public void testConfluentHypergeometric1F1() throws Exception {
+        assertEquals(1.0, 1.32382847084462 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 1.33333333333333), 1E-14);
+
+        assertEquals(1.0, 1.18850394032265 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.888888888888889), 1E-14);
+
+        assertEquals(1.0, 1.11547393799773 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.592592592592593), 1E-14);
+
+        assertEquals(1.0, 1.07293902048305 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.395061728395062), 1E-14);
+
+        assertEquals(1.0, 1.04695720520900 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.263374485596708), 1E-14);
+
+        assertEquals(1.0, 1.03059829570291 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.175582990397805), 1E-14);
+
+        assertEquals(1.0, 1.02009476435734 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.117055326931870), 1E-14);
+
+        assertEquals(1.0, 1.01326419084245 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.0780368846212468), 1E-14);
+
+        assertEquals(1.0, 1.00878480732077 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.0520245897474978), 1E-14);
+
+        assertEquals(1.0, 1.00583100626732 / SpecialFunctions.confluentHypergeometric1F1(0.25, 1.5, 0.0346830598316652), 1E-14);
+
+        assertEquals(0.018919655869471, SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 1.33333333333333), 1E-14);
+
+        assertEquals(1.0, 0.432122622618571 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.888888888888889), 1E-14);
+
+        assertEquals(1.0, 0.652955706161598 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.592592592592593), 1E-14);
+
+        assertEquals(1.0, 0.781012238118942 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.395061728395062), 1E-14);
+
+        assertEquals(1.0, 0.859080314343934 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.263374485596708), 1E-14);
+
+        assertEquals(1.0, 0.908191340178865 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.175582990397805), 1E-14);
+
+        assertEquals(1.0, 0.939711715868328 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.117055326931870), 1E-14);
+
+        assertEquals(1.0, 0.960206262262829 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.0780368846212468), 1E-14);
+
+        assertEquals(1.0, 0.973645236161197 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.0520245897474978), 1E-14);
+
+        assertEquals(1.0, 0.98250688056046 / SpecialFunctions.confluentHypergeometric1F1(-0.25, 0.5, 0.0346830598316652), 1E-14);
     }
 
     @Test
     public void testCalcLegendrePolynomial() throws Exception {
-    }
 
-    @Test
-    public void testWigner3J() throws Exception {
-    }
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(0, -2.00000000000000), 1E-13);
 
-    @Test
-    public void testPascal() throws Exception {
+        assertEquals(-2.00000000000000, SpecialFunctions.calcLegendrePolynomial(1, -2.00000000000000), 1E-13);
+
+        assertEquals(5.50000000000000, SpecialFunctions.calcLegendrePolynomial(2, -2.00000000000000), 1E-13);
+
+        assertEquals(-17.0000000000000, SpecialFunctions.calcLegendrePolynomial(3, -2.00000000000000), 1E-13);
+
+        assertEquals(55.3750000000000, SpecialFunctions.calcLegendrePolynomial(4, -2.00000000000000), 1E-13);
+
+        assertEquals(-1.75000000000000, SpecialFunctions.calcLegendrePolynomial(1, -1.75000000000000), 1E-13);
+
+        assertEquals(4.09375000000000, SpecialFunctions.calcLegendrePolynomial(2, -1.75000000000000), 1E-13);
+
+        assertEquals(-10.7734375000000, SpecialFunctions.calcLegendrePolynomial(3, -1.75000000000000), 1E-13);
+
+        assertEquals(29.9233398437500, SpecialFunctions.calcLegendrePolynomial(4, -1.75000000000000), 1E-13);
+
+        assertEquals(-1.50000000000000, SpecialFunctions.calcLegendrePolynomial(1, -1.50000000000000), 1E-13);
+
+        assertEquals(2.87500000000000, SpecialFunctions.calcLegendrePolynomial(2, -1.50000000000000), 1E-13);
+
+        assertEquals(-6.18750000000000, SpecialFunctions.calcLegendrePolynomial(3, -1.50000000000000), 1E-13);
+
+        assertEquals(14.0859375000000, SpecialFunctions.calcLegendrePolynomial(4, -1.50000000000000), 1E-13);
+
+        assertEquals(-1.25000000000000, SpecialFunctions.calcLegendrePolynomial(1, -1.25000000000000), 1E-13);
+
+        assertEquals(1.84375000000000, SpecialFunctions.calcLegendrePolynomial(2, -1.25000000000000), 1E-13);
+
+        assertEquals(-3.00781250000000, SpecialFunctions.calcLegendrePolynomial(3, -1.25000000000000), 1E-13);
+
+        assertEquals(5.19677734375000, SpecialFunctions.calcLegendrePolynomial(4, -1.25000000000000), 1E-13);
+
+        assertEquals(-1.00000000000000, SpecialFunctions.calcLegendrePolynomial(1, -1.00000000000000), 1E-13);
+
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(2, -1.00000000000000), 1E-13);
+
+        assertEquals(-1.00000000000000, SpecialFunctions.calcLegendrePolynomial(3, -1.00000000000000), 1E-13);
+
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(4, -1.00000000000000), 1E-13);
+
+        assertEquals(-0.750000000000000, SpecialFunctions.calcLegendrePolynomial(1, -0.750000000000000), 1E-13);
+
+        assertEquals(0.343750000000000, SpecialFunctions.calcLegendrePolynomial(2, -0.750000000000000), 1E-13);
+
+        assertEquals(0.0703125000000000, SpecialFunctions.calcLegendrePolynomial(3, -0.750000000000000), 1E-13);
+
+        assertEquals(-0.350097656250000, SpecialFunctions.calcLegendrePolynomial(4, -0.750000000000000), 1E-13);
+
+        assertEquals(-0.500000000000000, SpecialFunctions.calcLegendrePolynomial(1, -0.500000000000000), 1E-13);
+
+        assertEquals(-0.125000000000000, SpecialFunctions.calcLegendrePolynomial(2, -0.500000000000000), 1E-13);
+
+        assertEquals(0.437500000000000, SpecialFunctions.calcLegendrePolynomial(3, -0.500000000000000), 1E-13);
+
+        assertEquals(-0.289062500000000, SpecialFunctions.calcLegendrePolynomial(4, -0.500000000000000), 1E-13);
+
+        assertEquals(-0.250000000000000, SpecialFunctions.calcLegendrePolynomial(1, -0.250000000000000), 1E-13);
+
+        assertEquals(-0.406250000000000, SpecialFunctions.calcLegendrePolynomial(2, -0.250000000000000), 1E-13);
+
+        assertEquals(0.335937500000000, SpecialFunctions.calcLegendrePolynomial(3, -0.250000000000000), 1E-13);
+
+        assertEquals(0.157714843750000, SpecialFunctions.calcLegendrePolynomial(4, -0.250000000000000), 1E-13);
+
+        assertEquals(0, SpecialFunctions.calcLegendrePolynomial(1, 0), 1E-13);
+
+        assertEquals(-0.500000000000000, SpecialFunctions.calcLegendrePolynomial(2, 0), 1E-13);
+
+        assertEquals(0, SpecialFunctions.calcLegendrePolynomial(3, 0), 1E-13);
+
+        assertEquals(0.375000000000000, SpecialFunctions.calcLegendrePolynomial(4, 0), 1E-13);
+
+        assertEquals(0.250000000000000, SpecialFunctions.calcLegendrePolynomial(1, 0.250000000000000), 1E-13);
+
+        assertEquals(-0.406250000000000, SpecialFunctions.calcLegendrePolynomial(2, 0.250000000000000), 1E-13);
+
+        assertEquals(-0.335937500000000, SpecialFunctions.calcLegendrePolynomial(3, 0.250000000000000), 1E-13);
+
+        assertEquals(0.157714843750000, SpecialFunctions.calcLegendrePolynomial(4, 0.250000000000000), 1E-13);
+
+        assertEquals(0.500000000000000, SpecialFunctions.calcLegendrePolynomial(1, 0.500000000000000), 1E-13);
+
+        assertEquals(-0.125000000000000, SpecialFunctions.calcLegendrePolynomial(2, 0.500000000000000), 1E-13);
+
+        assertEquals(-0.437500000000000, SpecialFunctions.calcLegendrePolynomial(3, 0.500000000000000), 1E-13);
+
+        assertEquals(-0.289062500000000, SpecialFunctions.calcLegendrePolynomial(4, 0.500000000000000), 1E-13);
+
+        assertEquals(0.750000000000000, SpecialFunctions.calcLegendrePolynomial(1, 0.750000000000000), 1E-13);
+
+        assertEquals(0.343750000000000, SpecialFunctions.calcLegendrePolynomial(2, 0.750000000000000), 1E-13);
+
+        assertEquals(-0.0703125000000000, SpecialFunctions.calcLegendrePolynomial(3, 0.750000000000000), 1E-13);
+
+        assertEquals(-0.350097656250000, SpecialFunctions.calcLegendrePolynomial(4, 0.750000000000000), 1E-13);
+
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(1, 1.00000000000000), 1E-13);
+
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(2, 1.00000000000000), 1E-13);
+
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(3, 1.00000000000000), 1E-13);
+
+        assertEquals(1.00000000000000, SpecialFunctions.calcLegendrePolynomial(4, 1.00000000000000), 1E-13);
+
+        assertEquals(1.25000000000000, SpecialFunctions.calcLegendrePolynomial(1, 1.25000000000000), 1E-13);
+
+        assertEquals(1.84375000000000, SpecialFunctions.calcLegendrePolynomial(2, 1.25000000000000), 1E-13);
+
+        assertEquals(3.00781250000000, SpecialFunctions.calcLegendrePolynomial(3, 1.25000000000000), 1E-13);
+
+        assertEquals(5.19677734375000, SpecialFunctions.calcLegendrePolynomial(4, 1.25000000000000), 1E-13);
+
+        assertEquals(1.50000000000000, SpecialFunctions.calcLegendrePolynomial(1, 1.50000000000000), 1E-13);
+
+        assertEquals(2.87500000000000, SpecialFunctions.calcLegendrePolynomial(2, 1.50000000000000), 1E-13);
+
+        assertEquals(6.18750000000000, SpecialFunctions.calcLegendrePolynomial(3, 1.50000000000000), 1E-13);
+
+        assertEquals(14.0859375000000, SpecialFunctions.calcLegendrePolynomial(4, 1.50000000000000), 1E-13);
+
+        assertEquals(1.75000000000000, SpecialFunctions.calcLegendrePolynomial(1, 1.75000000000000), 1E-13);
+
+        assertEquals(4.09375000000000, SpecialFunctions.calcLegendrePolynomial(2, 1.75000000000000), 1E-13);
+
+        assertEquals(10.7734375000000, SpecialFunctions.calcLegendrePolynomial(3, 1.75000000000000), 1E-13);
+
+        assertEquals(29.9233398437500, SpecialFunctions.calcLegendrePolynomial(4, 1.75000000000000), 1E-13);
+
+        assertEquals(2.00000000000000, SpecialFunctions.calcLegendrePolynomial(1, 2.00000000000000), 1E-13);
+
+        assertEquals(5.50000000000000, SpecialFunctions.calcLegendrePolynomial(2, 2.00000000000000), 1E-13);
+
+        assertEquals(17.0000000000000, SpecialFunctions.calcLegendrePolynomial(3, 2.00000000000000), 1E-13);
+
+        assertEquals(55.3750000000000, SpecialFunctions.calcLegendrePolynomial(4, 2.00000000000000), 1E-13);
+
     }
 
     @Test
     public void testBesselI() throws Exception {
+        assertEquals(1.0, 0.1005008340281251 / SpecialFunctions.besselI(1, 0.20000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.005016687513894678 / SpecialFunctions.besselI(2, 0.20000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.0001670837502315642 / SpecialFunctions.besselI(3, 0.20000000000000000000), 1E-14);
+
+        assertEquals(1.0, 4.175006947752356E-6 / SpecialFunctions.besselI(4, 0.20000000000000000000), 1E-14);
+
+        assertEquals(1.0, 8.347232146991889E-8 / SpecialFunctions.besselI(5, 0.20000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2040267557335706 / SpecialFunctions.besselI(1, 0.40000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.02026800356148826 / SpecialFunctions.besselI(2, 0.40000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.001346720118688000 / SpecialFunctions.besselI(3, 0.40000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.00006720178116825773 / SpecialFunctions.besselI(4, 0.40000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.684495322845460E-6 / SpecialFunctions.besselI(5, 0.40000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.3137040256049221 / SpecialFunctions.besselI(1, 0.60000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.04636527896759911 / SpecialFunctions.besselI(2, 0.60000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.004602165820928096 / SpecialFunctions.besselI(3, 0.60000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.0003436207583181480 / SpecialFunctions.besselI(4, 0.60000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.00002055571001945543 / SpecialFunctions.besselI(5, 0.60000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.4328648026206398 / SpecialFunctions.besselI(1, 0.80000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.08435291631820318 / SpecialFunctions.besselI(2, 0.80000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.01110022102962393 / SpecialFunctions.besselI(3, 0.80000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.001101258596023714 / SpecialFunctions.besselI(4, 0.80000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.00008763506938678689 / SpecialFunctions.besselI(5, 0.80000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.5651591039924850 / SpecialFunctions.besselI(1, 1.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.1357476697670383 / SpecialFunctions.besselI(2, 1.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.02216842492433190 / SpecialFunctions.besselI(3, 1.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.002737120221046866 / SpecialFunctions.besselI(4, 1.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.0002714631559569719 / SpecialFunctions.besselI(5, 1.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.7146779415526431 / SpecialFunctions.besselI(1, 1.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2025956815463259 / SpecialFunctions.besselI(2, 1.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.03935900306489002 / SpecialFunctions.besselI(3, 1.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.005800666221875796 / SpecialFunctions.besselI(4, 1.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.0006878949190513823 / SpecialFunctions.besselI(5, 1.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.8860919814143274 / SpecialFunctions.besselI(1, 1.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2875494119964631 / SpecialFunctions.besselI(2, 1.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.06452223285300407 / SpecialFunctions.besselI(3, 1.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.01102555691215997 / SpecialFunctions.besselI(4, 1.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.001519050497804235 / SpecialFunctions.besselI(5, 1.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.084810635129880 / SpecialFunctions.besselI(1, 1.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.3939673458265599 / SpecialFunctions.besselI(2, 1.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.09989227056347994 / SpecialFunctions.besselI(3, 1.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.01937133121351008 / SpecialFunctions.besselI(4, 1.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.003035614495929543 / SpecialFunctions.besselI(5, 1.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.317167230391899 / SpecialFunctions.besselI(1, 1.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.5260402117381632 / SpecialFunctions.besselI(2, 1.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.1481889820848698 / SpecialFunctions.besselI(3, 1.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.03207693812193060 / SpecialFunctions.besselI(4, 1.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.005624812654067089 / SpecialFunctions.besselI(5, 1.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.590636854637329 / SpecialFunctions.besselI(1, 2.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.6889484476987382 / SpecialFunctions.besselI(2, 2.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2127399592398527 / SpecialFunctions.besselI(3, 2.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.05072856997918024 / SpecialFunctions.besselI(4, 2.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.009825679323131702 / SpecialFunctions.besselI(5, 2.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.914094650586386 / SpecialFunctions.besselI(1, 2.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.8890568175796904 / SpecialFunctions.besselI(2, 2.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2976277095324036 / SpecialFunctions.besselI(3, 2.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.07734488249131686 / SpecialFunctions.besselI(4, 2.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.01637359138216051 / SpecialFunctions.besselI(5, 2.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.298123812543222 / SpecialFunctions.besselI(1, 2.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.134153480870062 / SpecialFunctions.besselI(2, 2.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.4078680110931191 / SpecialFunctions.besselI(3, 2.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.1144834531372640 / SpecialFunctions.besselI(4, 2.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.02625650063557234 / SpecialFunctions.besselI(5, 2.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.755384340504706 / SpecialFunctions.besselI(1, 2.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.433742488470821 / SpecialFunctions.besselI(2, 2.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.5496266659342133 / SpecialFunctions.besselI(3, 2.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.1653732593918667 / SpecialFunctions.besselI(4, 2.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.04078586780539262 / SpecialFunctions.besselI(5, 2.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.301055822635088 / SpecialFunctions.besselI(1, 2.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.799400687332901 / SpecialFunctions.besselI(2, 2.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.7304834121595154 / SpecialFunctions.besselI(3, 2.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2340790898482246 / SpecialFunctions.besselI(4, 2.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.06168601259315954 / SpecialFunctions.besselI(5, 2.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.953370217402609 / SpecialFunctions.besselI(1, 3.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.245212440929951 / SpecialFunctions.besselI(2, 3.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.9597536294960079 / SpecialFunctions.besselI(3, 3.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.3257051819379354 / SpecialFunctions.besselI(4, 3.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.09120647766151335 / SpecialFunctions.besselI(5, 3.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 4.734253894709620 / SpecialFunctions.besselI(1, 3.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.788298502987037 / SpecialFunctions.besselI(2, 3.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.248880765975824 / SpecialFunctions.besselI(3, 3.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.4466470667823664 / SpecialFunctions.besselI(4, 3.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.1322630990199083 / SpecialFunctions.besselI(5, 3.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 5.670102192635220 / SpecialFunctions.besselI(1, 3.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.449458929469693 / SpecialFunctions.besselI(2, 3.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.611915216788522 / SpecialFunctions.besselI(3, 3.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.6049026645487712 / SpecialFunctions.besselI(4, 3.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.1886148296149430 / SpecialFunctions.besselI(5, 3.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 6.792714601361299 / SpecialFunctions.besselI(1, 3.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 4.253954212964399 / SpecialFunctions.besselI(2, 3.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.066098809178633 / SpecialFunctions.besselI(3, 3.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.8104561976666769 / SpecialFunctions.besselI(4, 3.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.2650850365860180 / SpecialFunctions.besselI(5, 3.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 8.140424578907956 / SpecialFunctions.besselI(1, 3.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 5.232454037200033 / SpecialFunctions.besselI(2, 3.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.632578223960553 / SpecialFunctions.besselI(3, 3.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.075751578314950 / SpecialFunctions.besselI(4, 3.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.3678380590869744 / SpecialFunctions.besselI(5, 3.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 9.759465153704450 / SpecialFunctions.besselI(1, 4.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 6.422189375284106 / SpecialFunctions.besselI(2, 4.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.337275778420344 / SpecialFunctions.besselI(3, 4.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.416275707653589 / SpecialFunctions.besselI(4, 4.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.5047243631131664 / SpecialFunctions.besselI(5, 4.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 11.70562014305162 / SpecialFunctions.besselI(1, 4.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 7.868351333273067 / SpecialFunctions.besselI(2, 4.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 4.211952206601076 / SpecialFunctions.besselI(3, 4.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.851276752414387 / SpecialFunctions.besselI(4, 4.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.6857107734308141 / SpecialFunctions.besselI(5, 4.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 14.04622133753311 / SpecialFunctions.besselI(1, 4.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 9.625789462431949 / SpecialFunctions.besselI(2, 4.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 5.295503644413152 / SpecialFunctions.besselI(3, 4.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.404648129141286 / SpecialFunctions.besselI(4, 4.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 0.9234161368835410 / SpecialFunctions.besselI(5, 4.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 16.86256476197666 / SpecialFunctions.besselI(1, 4.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 11.76107358300787 / SpecialFunctions.besselI(2, 4.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 6.635544255013292 / SpecialFunctions.besselI(3, 4.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.106015859077489 / SpecialFunctions.besselI(4, 4.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.233777543574181 / SpecialFunctions.besselI(5, 4.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 20.25283460023856 / SpecialFunctions.besselI(1, 4.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 14.35499690967306 / SpecialFunctions.besselI(2, 4.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 8.290337175511006 / SpecialFunctions.besselI(3, 4.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.992075440284307 / SpecialFunctions.besselI(4, 4.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 1.636878108370495 / SpecialFunctions.besselI(5, 4.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 24.33564214245053 / SpecialFunctions.besselI(1, 5.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 17.50561496662424 / SpecialFunctions.besselI(2, 5.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 10.33115016915114 / SpecialFunctions.besselI(3, 5.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 5.108234763642870 / SpecialFunctions.besselI(4, 5.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.157974547322546 / SpecialFunctions.besselI(5, 5.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 29.25430988179835 / SpecialFunctions.besselI(1, 5.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 21.33193506376818 / SpecialFunctions.besselI(2, 5.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 12.84512906351513 / SpecialFunctions.besselI(3, 5.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 6.510632298173797 / SpecialFunctions.besselI(4, 5.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 2.828771681709292 / SpecialFunctions.besselI(5, 5.2000000000000000000), 1E-14);
+
+        assertEquals(1.0, 35.18205850608358 / SpecialFunctions.besselI(1, 5.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 25.97839574633562 / SpecialFunctions.besselI(2, 5.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 15.93880239768683 / SpecialFunctions.besselI(3, 5.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 8.268615304461366 / SpecialFunctions.besselI(4, 5.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 3.689001946632952 / SpecialFunctions.besselI(5, 5.4000000000000000000), 1E-14);
+
+        assertEquals(1.0, 42.32828803246685 / SpecialFunctions.besselI(1, 5.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 31.62030556675627 / SpecialFunctions.besselI(2, 5.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 19.74235548478380 / SpecialFunctions.besselI(3, 5.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 10.46778183305934 / SpecialFunctions.besselI(4, 5.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 4.788381437556167 / SpecialFunctions.besselI(5, 5.6000000000000000000), 1E-14);
+
+        assertEquals(1.0, 50.94618497877481 / SpecialFunctions.besselI(1, 5.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 38.47044689994190 / SpecialFunctions.besselI(2, 5.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 24.41484228915970 / SpecialFunctions.besselI(3, 5.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 13.21371349736290 / SpecialFunctions.besselI(4, 5.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 6.189030568659158 / SpecialFunctions.besselI(5, 5.8000000000000000000), 1E-14);
+
+        assertEquals(1.0, 61.34193677764024 / SpecialFunctions.besselI(1, 6.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 46.78709471726456 / SpecialFunctions.besselI(2, 6.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 30.15054029946386 / SpecialFunctions.besselI(3, 6.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 16.63655441780070 / SpecialFunctions.besselI(4, 6.0000000000000000000), 1E-14);
+
+        assertEquals(1.0, 7.968467742396263 / SpecialFunctions.besselI(5, 6.0000000000000000000), 1E-14);
     }
 
+    @Test
+    public void testBesselJ() throws Exception {
+        assertEquals(0.09950083263923600,SpecialFunctions.besselJ(1,0.20000000000000000000),1E-13);
 
-    private static final double EPSILON = 1e-10;
+        assertEquals(0.004983354152783563,SpecialFunctions.besselJ(2,0.20000000000000000000),1E-13);
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+        assertEquals(0.0001662504164352678,SpecialFunctions.besselJ(3,0.20000000000000000000),1E-13);
+
+        assertEquals(4.158340274471933E-6,SpecialFunctions.besselJ(4,0.20000000000000000000),1E-13);
+
+        assertEquals(8.319454360946915E-8,SpecialFunctions.besselJ(5,0.20000000000000000000),1E-13);
+
+        assertEquals(0.1960265779553187,SpecialFunctions.besselJ(1,0.40000000000000000000),1E-13);
+
+        assertEquals(0.01973466311703027,SpecialFunctions.besselJ(2,0.40000000000000000000),1E-13);
+
+        assertEquals(0.001320053214983958,SpecialFunctions.besselJ(3,0.40000000000000000000),1E-13);
+
+        assertEquals(0.00006613510772909677,SpecialFunctions.besselJ(4,0.40000000000000000000),1E-13);
+
+        assertEquals(2.648939597977585E-6,SpecialFunctions.besselJ(5,0.40000000000000000000),1E-13);
+
+        assertEquals(0.2867009880639157,SpecialFunctions.besselJ(1,0.60000000000000000000),1E-13);
+
+        assertEquals(0.04366509671584169,SpecialFunctions.besselJ(2,0.60000000000000000000),1E-13);
+
+        assertEquals(0.004399656708362193,SpecialFunctions.besselJ(3,0.60000000000000000000),1E-13);
+
+        assertEquals(0.0003314703677802370,SpecialFunctions.besselJ(4,0.60000000000000000000),1E-13);
+
+        assertEquals(0.00001994819537430024,SpecialFunctions.besselJ(5,0.60000000000000000000),1E-13);
+
+        assertEquals(0.3688420460941700,SpecialFunctions.besselJ(1,0.80000000000000000000),1E-13);
+
+        assertEquals(0.07581776248494472,SpecialFunctions.besselJ(2,0.80000000000000000000),1E-13);
+
+        assertEquals(0.01024676633055360,SpecialFunctions.besselJ(3,0.80000000000000000000),1E-13);
+
+        assertEquals(0.001032984994207302,SpecialFunctions.besselJ(4,0.80000000000000000000),1E-13);
+
+        assertEquals(0.00008308361151942143,SpecialFunctions.besselJ(5,0.80000000000000000000),1E-13);
+
+        assertEquals(0.4400505857449335,SpecialFunctions.besselJ(1,1.0000000000000000000),1E-13);
+
+        assertEquals(0.1149034849319005,SpecialFunctions.besselJ(2,1.0000000000000000000),1E-13);
+
+        assertEquals(0.01956335398266841,SpecialFunctions.besselJ(3,1.0000000000000000000),1E-13);
+
+        assertEquals(0.002476638964109955,SpecialFunctions.besselJ(4,1.0000000000000000000),1E-13);
+
+        assertEquals(0.0002497577302112344,SpecialFunctions.besselJ(5,1.0000000000000000000),1E-13);
+
+        assertEquals(0.4982890575672155,SpecialFunctions.besselJ(1,1.2000000000000000000),1E-13);
+
+        assertEquals(0.1593490183476631,SpecialFunctions.besselJ(2,1.2000000000000000000),1E-13);
+
+        assertEquals(0.03287433692499494,SpecialFunctions.besselJ(3,1.2000000000000000000),1E-13);
+
+        assertEquals(0.005022666277311587,SpecialFunctions.besselJ(4,1.2000000000000000000),1E-13);
+
+        assertEquals(0.0006101049237489684,SpecialFunctions.besselJ(5,1.2000000000000000000),1E-13);
+
+        assertEquals(0.5419477139308545,SpecialFunctions.besselJ(1,1.4000000000000000000),1E-13);
+
+        assertEquals(0.2073558995269320,SpecialFunctions.besselJ(2,1.4000000000000000000),1E-13);
+
+        assertEquals(0.05049771328895130,SpecialFunctions.besselJ(3,1.4000000000000000000),1E-13);
+
+        assertEquals(0.009062871711430658,SpecialFunctions.besselJ(4,1.4000000000000000000),1E-13);
+
+        assertEquals(0.001290125062081034,SpecialFunctions.besselJ(5,1.4000000000000000000),1E-13);
+
+        assertEquals(0.5698959352616804,SpecialFunctions.besselJ(1,1.6000000000000000000),1E-13);
+
+        assertEquals(0.2569677514377197,SpecialFunctions.besselJ(2,1.6000000000000000000),1E-13);
+
+        assertEquals(0.07252344333261900,SpecialFunctions.besselJ(3,1.6000000000000000000),1E-13);
+
+        assertEquals(0.01499516105960151,SpecialFunctions.besselJ(4,1.6000000000000000000),1E-13);
+
+        assertEquals(0.002452361965388557,SpecialFunctions.besselJ(5,1.6000000000000000000),1E-13);
+
+        assertEquals(0.5815169517311652,SpecialFunctions.besselJ(1,1.8000000000000000000),1E-13);
+
+        assertEquals(0.3061435353254030,SpecialFunctions.besselJ(2,1.8000000000000000000),1E-13);
+
+        assertEquals(0.09880201565861918,SpecialFunctions.besselJ(3,1.8000000000000000000),1E-13);
+
+        assertEquals(0.02319651686999431,SpecialFunctions.besselJ(4,1.8000000000000000000),1E-13);
+
+        assertEquals(0.004293614874688868,SpecialFunctions.besselJ(5,1.8000000000000000000),1E-13);
+
+        assertEquals(0.5767248077568734,SpecialFunctions.besselJ(1,2.0000000000000000000),1E-13);
+
+        assertEquals(0.3528340286156377,SpecialFunctions.besselJ(2,2.0000000000000000000),1E-13);
+
+        assertEquals(0.1289432494744021,SpecialFunctions.besselJ(3,2.0000000000000000000),1E-13);
+
+        assertEquals(0.03399571980756843,SpecialFunctions.besselJ(4,2.0000000000000000000),1E-13);
+
+        assertEquals(0.007039629755871685,SpecialFunctions.besselJ(5,2.0000000000000000000),1E-13);
+
+        assertEquals(0.5559630498190639,SpecialFunctions.besselJ(1,2.2000000000000000000),1E-13);
+
+        assertEquals(0.3950586874587933,SpecialFunctions.besselJ(2,2.2000000000000000000),1E-13);
+
+        assertEquals(0.1623254728332875,SpecialFunctions.besselJ(3,2.2000000000000000000),1E-13);
+
+        assertEquals(0.04764714754108161,SpecialFunctions.besselJ(4,2.2000000000000000000),1E-13);
+
+        assertEquals(0.01093688186155476,SpecialFunctions.besselJ(5,2.2000000000000000000),1E-13);
+
+        assertEquals(0.5201852681819310,SpecialFunctions.besselJ(1,2.4000000000000000000),1E-13);
+
+        assertEquals(0.4309800401876987,SpecialFunctions.besselJ(2,2.4000000000000000000),1E-13);
+
+        assertEquals(0.1981147987975668,SpecialFunctions.besselJ(3,2.4000000000000000000),1E-13);
+
+        assertEquals(0.06430695680621835,SpecialFunctions.besselJ(4,2.4000000000000000000),1E-13);
+
+        assertEquals(0.01624172388982766,SpecialFunctions.besselJ(5,2.4000000000000000000),1E-13);
+
+        assertEquals(0.4708182665175787,SpecialFunctions.besselJ(1,2.6000000000000000000),1E-13);
+
+        assertEquals(0.4589728517182526,SpecialFunctions.besselJ(2,2.6000000000000000000),1E-13);
+
+        assertEquals(0.2352938130489638,SpecialFunctions.besselJ(3,2.6000000000000000000),1E-13);
+
+        assertEquals(0.08401287070243310,SpecialFunctions.besselJ(4,2.6000000000000000000),1E-13);
+
+        assertEquals(0.02320732757390727,SpecialFunctions.besselJ(5,2.6000000000000000000),1E-13);
+
+        assertEquals(0.4097092468522887,SpecialFunctions.besselJ(1,2.8000000000000000000),1E-13);
+
+        assertEquals(0.4776854954017364,SpecialFunctions.besselJ(2,2.8000000000000000000),1E-13);
+
+        assertEquals(0.2726986037216204,SpecialFunctions.besselJ(3,2.8000000000000000000),1E-13);
+
+        assertEquals(0.1066686554303074,SpecialFunctions.besselJ(4,2.8000000000000000000),1E-13);
+
+        assertEquals(0.03206898322211490,SpecialFunctions.besselJ(5,2.8000000000000000000),1E-13);
+
+        assertEquals(0.3390589585259365,SpecialFunctions.besselJ(1,3.0000000000000000000),1E-13);
+
+        assertEquals(0.4860912605858911,SpecialFunctions.besselJ(2,3.0000000000000000000),1E-13);
+
+        assertEquals(0.3090627222552516,SpecialFunctions.besselJ(3,3.0000000000000000000),1E-13);
+
+        assertEquals(0.1320341839246122,SpecialFunctions.besselJ(4,3.0000000000000000000),1E-13);
+
+        assertEquals(0.04302843487704758,SpecialFunctions.besselJ(5,3.0000000000000000000),1E-13);
+
+        assertEquals(0.2613432487805048,SpecialFunctions.besselJ(1,3.2000000000000000000),1E-13);
+
+        assertEquals(0.4835277001449384,SpecialFunctions.besselJ(2,3.2000000000000000000),1E-13);
+
+        assertEquals(0.3430663764006682,SpecialFunctions.besselJ(3,3.2000000000000000000),1E-13);
+
+        assertEquals(0.1597217556063144,SpecialFunctions.besselJ(4,3.2000000000000000000),1E-13);
+
+        assertEquals(0.05623801261511791,SpecialFunctions.besselJ(5,3.2000000000000000000),1E-13);
+
+        assertEquals(0.1792258516815071,SpecialFunctions.besselJ(1,3.4000000000000000000),1E-13);
+
+        assertEquals(0.4697225683393576,SpecialFunctions.besselJ(2,3.4000000000000000000),1E-13);
+
+        assertEquals(0.3733889346000901,SpecialFunctions.besselJ(3,3.4000000000000000000),1E-13);
+
+        assertEquals(0.1891990809549190,SpecialFunctions.besselJ(4,3.4000000000000000000),1E-13);
+
+        assertEquals(0.07178537352913107,SpecialFunctions.besselJ(5,3.4000000000000000000),1E-13);
+
+        assertEquals(0.09546554717787640,SpecialFunctions.besselJ(1,3.6000000000000000000),1E-13);
+
+        assertEquals(0.4448053987996180,SpecialFunctions.besselJ(2,3.6000000000000000000),1E-13);
+
+        assertEquals(0.3987626737105880,SpecialFunctions.besselJ(3,3.6000000000000000000),1E-13);
+
+        assertEquals(0.2197990573846954,SpecialFunctions.besselJ(4,3.6000000000000000000),1E-13);
+
+        assertEquals(0.08967967603317951,SpecialFunctions.besselJ(5,3.6000000000000000000),1E-13);
+
+        assertEquals(0.01282100292673163,SpecialFunctions.besselJ(1,3.8000000000000000000),1E-13);
+
+        assertEquals(0.4093043064557913,SpecialFunctions.besselJ(2,3.8000000000000000000),1E-13);
+
+        assertEquals(0.4180256354477856,SpecialFunctions.besselJ(3,3.8000000000000000000),1E-13);
+
+        assertEquals(0.2507361705670280,SpecialFunctions.besselJ(4,3.8000000000000000000),1E-13);
+
+        assertEquals(0.1098399867985891,SpecialFunctions.besselJ(5,3.8000000000000000000),1E-13);
+
+        assertEquals(-0.06604332802354914,SpecialFunctions.besselJ(1,4.0000000000000000000),1E-13);
+
+        assertEquals(0.3641281458520728,SpecialFunctions.besselJ(2,4.0000000000000000000),1E-13);
+
+        assertEquals(0.4301714738756219,SpecialFunctions.besselJ(3,4.0000000000000000000),1E-13);
+
+        assertEquals(0.2811290649613601,SpecialFunctions.besselJ(4,4.0000000000000000000),1E-13);
+
+        assertEquals(0.1320866560470983,SpecialFunctions.besselJ(5,4.0000000000000000000),1E-13);
+
+        assertEquals(-0.1386469421260462,SpecialFunctions.besselJ(1,4.2000000000000000000),1E-13);
+
+        assertEquals(0.3105347009742123,SpecialFunctions.besselJ(2,4.2000000000000000000),1E-13);
+
+        assertEquals(0.4343942763872008,SpecialFunctions.besselJ(3,4.2000000000000000000),1E-13);
+
+        assertEquals(0.3100285510075031,SpecialFunctions.besselJ(4,4.2000000000000000000),1E-13);
+
+        assertEquals(0.1561362969604241,SpecialFunctions.besselJ(5,4.2000000000000000000),1E-13);
+
+        assertEquals(-0.2027755219230866,SpecialFunctions.besselJ(1,4.4000000000000000000),1E-13);
+
+        assertEquals(0.2500860982206644,SpecialFunctions.besselJ(2,4.4000000000000000000),1E-13);
+
+        assertEquals(0.4301265203055088,SpecialFunctions.besselJ(3,4.4000000000000000000),1E-13);
+
+        assertEquals(0.3364500658323021,SpecialFunctions.besselJ(4,4.4000000000000000000),1E-13);
+
+        assertEquals(0.1816008721168587,SpecialFunctions.besselJ(5,4.4000000000000000000),1E-13);
+
+        assertEquals(-0.2565528360974446,SpecialFunctions.besselJ(1,4.6000000000000000000),1E-13);
+
+        assertEquals(0.1845931052274261,SpecialFunctions.besselJ(2,4.6000000000000000000),1E-13);
+
+        assertEquals(0.4170685797734673,SpecialFunctions.besselJ(3,4.6000000000000000000),1E-13);
+
+        assertEquals(0.3594093901292703,SpecialFunctions.besselJ(4,4.6000000000000000000),1E-13);
+
+        assertEquals(0.2079912291470029,SpecialFunctions.besselJ(5,4.6000000000000000000),1E-13);
+
+        assertEquals(-0.2984998580995579,SpecialFunctions.besselJ(1,4.8000000000000000000),1E-13);
+
+        assertEquals(0.1160503864163677,SpecialFunctions.besselJ(2,4.8000000000000000000),1E-13);
+
+        assertEquals(0.3952085134465309,SpecialFunctions.besselJ(3,4.8000000000000000000),1E-13);
+
+        assertEquals(0.3779602553917960,SpecialFunctions.besselJ(4,4.8000000000000000000),1E-13);
+
+        assertEquals(0.2347252455397957,SpecialFunctions.besselJ(5,4.8000000000000000000),1E-13);
+
+        assertEquals(-0.3275791375914652,SpecialFunctions.besselJ(1,5.0000000000000000000),1E-13);
+
+        assertEquals(0.04656511627775222,SpecialFunctions.besselJ(2,5.0000000000000000000),1E-13);
+
+        assertEquals(0.3648312306136670,SpecialFunctions.besselJ(3,5.0000000000000000000),1E-13);
+
+        assertEquals(0.3912323604586482,SpecialFunctions.besselJ(4,5.0000000000000000000),1E-13);
+
+        assertEquals(0.2611405461201701,SpecialFunctions.besselJ(5,5.0000000000000000000),1E-13);
+
+        assertEquals(-0.3432230058719219,SpecialFunctions.besselJ(1,5.2000000000000000000),1E-13);
+
+        assertEquals(-0.02171840862129112,SpecialFunctions.besselJ(2,5.2000000000000000000),1E-13);
+
+        assertEquals(0.3265165377016980,SpecialFunctions.besselJ(3,5.2000000000000000000),1E-13);
+
+        assertEquals(0.3984682598155580,SpecialFunctions.besselJ(4,5.2000000000000000000),1E-13);
+
+        assertEquals(0.2865115543222374,SpecialFunctions.besselJ(5,5.2000000000000000000),1E-13);
+
+        assertEquals(-0.3453447907795863,SpecialFunctions.besselJ(1,5.4000000000000000000),1E-13);
+
+        assertEquals(-0.08669537682152215,SpecialFunctions.besselJ(2,5.4000000000000000000),1E-13);
+
+        assertEquals(0.2811259931340144,SpecialFunctions.besselJ(3,5.4000000000000000000),1E-13);
+
+        assertEquals(0.3990575914148714,SpecialFunctions.besselJ(4,5.4000000000000000000),1E-13);
+
+        assertEquals(0.3100704385917211,SpecialFunctions.besselJ(5,5.4000000000000000000),1E-13);
+
+        assertEquals(-0.3343328362910075,SpecialFunctions.besselJ(1,5.6000000000000000000),1E-13);
+
+        assertEquals(-0.1463754690747600,SpecialFunctions.besselJ(2,5.6000000000000000000),1E-13);
+
+        assertEquals(0.2297789298090361,SpecialFunctions.besselJ(3,5.6000000000000000000),1E-13);
+
+        assertEquals(0.3925671795844415,SpecialFunctions.besselJ(4,5.6000000000000000000),1E-13);
+
+        assertEquals(0.3310313267401661,SpecialFunctions.besselJ(5,5.6000000000000000000),1E-13);
+
+        assertEquals(-0.3110277443039424,SpecialFunctions.besselJ(1,5.8000000000000000000),1E-13);
+
+        assertEquals(-0.1989535138865205,SpecialFunctions.besselJ(2,5.8000000000000000000),1E-13);
+
+        assertEquals(0.1738184243822042,SpecialFunctions.besselJ(3,5.8000000000000000000),1E-13);
+
+        assertEquals(0.3787656770405248,SpecialFunctions.besselJ(4,5.8000000000000000000),1E-13);
+
+        assertEquals(0.3486169922254162,SpecialFunctions.besselJ(5,5.8000000000000000000),1E-13);
+
+        assertEquals(-0.2766838581275656,SpecialFunctions.besselJ(1,6.0000000000000000000),1E-13);
+
+        assertEquals(-0.2428732099601855,SpecialFunctions.besselJ(2,6.0000000000000000000),1E-13);
+
+        assertEquals(0.1147683848207753,SpecialFunctions.besselJ(3,6.0000000000000000000),1E-13);
+
+        assertEquals(0.3576415947809608,SpecialFunctions.besselJ(4,6.0000000000000000000),1E-13);
+
+        assertEquals(0.3620870748871724,SpecialFunctions.besselJ(5,6.0000000000000000000),1E-13);
+
+    }
 
     @Test
     public void testFactorial() {
@@ -88,7 +864,7 @@ public class SpecialFunctionsTest {
         assertEquals(10.60460290274525, SpecialFunctions.lnFactorial(8), EPSILON);
         assertEquals(42.335616460753485, SpecialFunctions.lnFactorial(20), EPSILON);
         assertEquals(363.73937555556349, SpecialFunctions.lnFactorial(100), EPSILON);
-        assertEquals(82108.92783681436, SpecialFunctions.lnFactorial(10000),1e-9);
+        assertEquals(82108.92783681436, SpecialFunctions.lnFactorial(10000), 1e-9);
     }
 
 


### PR DESCRIPTION
Implement test methods for specialFunctions. 
Delete wigner3J, gammaQ and sgn methods.
Add unmodified bessel functions.The order of bessel functions can be double now. 
