### PR TITLE
Add logging framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,8 @@ project(':etomica-core') {
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
         compile 'com.github.therapi:therapi-runtime-javadoc:0.2.1'
         compile "io.github.lukehutch:fast-classpath-scanner:2.9.4"
+        compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.10.0'
+        compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.10.0'
 
         compile files("$rootProject.projectDir/libs/ptolemy.jar")
 

--- a/etomica-core/src/main/java/etomica/action/activity/ActivityIntegrate.java
+++ b/etomica-core/src/main/java/etomica/action/activity/ActivityIntegrate.java
@@ -8,11 +8,14 @@ import etomica.action.Activity;
 import etomica.integrator.Integrator;
 import etomica.exception.ConfigurationOverlapException;
 import etomica.util.Debug;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Activity that repeatedly invokes an Integrator's doStep method.
  */
 public class ActivityIntegrate extends Activity {
+    private final Logger LOG = LogManager.getLogger(this.getClass());
 
     /**
 	 * Constructs activity to generate configurations with
@@ -48,7 +51,12 @@ public class ActivityIntegrate extends Activity {
             }
         }
         integrator.resetStepCount();
+        long startTime = 0, endTime;
         for (stepCount = 0; stepCount < maxSteps; stepCount++) {
+            if (LOG.isDebugEnabled()) {
+                startTime = System.nanoTime();
+                LOG.debug("Beginning step {}", stepCount);
+            }
             if (Debug.ON) {
                 if (stepCount == Debug.START) Debug.DEBUG_NOW = true;
                 if (stepCount == Debug.STOP) break;
@@ -60,6 +68,11 @@ public class ActivityIntegrate extends Activity {
             if(sleepPeriod > 0) {
                 try { Thread.sleep(sleepPeriod); }
                 catch (InterruptedException e) { }
+            }
+
+            if (LOG.isDebugEnabled()) {
+                endTime = System.nanoTime();
+                LOG.debug("Step {} done in {}ms", stepCount, (endTime - startTime) / 1_000_000);
             }
         }
 	}
@@ -112,7 +125,12 @@ public class ActivityIntegrate extends Activity {
 	public Integrator getIntegrator() {
 		return integrator;
 	}
-    
+
+    @Override
+    public String toString() {
+        return "integration";
+    }
+
     private static final long serialVersionUID = 1L;
 	private final Integrator integrator;
     private boolean ignoreOverlap;

--- a/etomica-core/src/main/java/etomica/action/activity/ActivityIntegrate.java
+++ b/etomica-core/src/main/java/etomica/action/activity/ActivityIntegrate.java
@@ -55,7 +55,6 @@ public class ActivityIntegrate extends Activity {
         for (stepCount = 0; stepCount < maxSteps; stepCount++) {
             if (LOG.isDebugEnabled()) {
                 startTime = System.nanoTime();
-                LOG.debug("Beginning step {}", stepCount);
             }
             if (Debug.ON) {
                 if (stepCount == Debug.START) Debug.DEBUG_NOW = true;

--- a/etomica-core/src/main/java/etomica/simulation/Simulation.java
+++ b/etomica-core/src/main/java/etomica/simulation/Simulation.java
@@ -16,11 +16,10 @@ import etomica.meta.javadoc.KeepSimJavadoc;
 import etomica.space.Boundary;
 import etomica.space.Space;
 import etomica.species.ISpecies;
+import etomica.util.logging.SimLogger;
 import etomica.util.random.IRandom;
 import etomica.util.random.RandomMersenneTwister;
 import etomica.util.random.RandomNumberGeneratorUnix;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 
@@ -31,7 +30,7 @@ import java.util.*;
  */
 @KeepSimJavadoc
 public class Simulation {
-    protected final Logger LOG = LogManager.getLogger(this.getClass());
+    protected final SimLogger LOG = SimLogger.create();
 
     protected final Space space;
     protected final SimulationEventManager eventManager;

--- a/etomica-core/src/main/java/etomica/simulation/Simulation.java
+++ b/etomica-core/src/main/java/etomica/simulation/Simulation.java
@@ -19,6 +19,8 @@ import etomica.species.ISpecies;
 import etomica.util.random.IRandom;
 import etomica.util.random.RandomMersenneTwister;
 import etomica.util.random.RandomNumberGeneratorUnix;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 
@@ -29,6 +31,7 @@ import java.util.*;
  */
 @KeepSimJavadoc
 public class Simulation {
+    protected final Logger LOG = LogManager.getLogger(this.getClass());
 
     protected final Space space;
     protected final SimulationEventManager eventManager;
@@ -47,6 +50,7 @@ public class Simulation {
      * @param space the space used to construct Vectors etc.
      */
     public Simulation(Space space) {
+        LOG.info("Initializing Simulation");
         this.space = space;
         boxes = new ArrayList<>();
         controller = new Controller();

--- a/etomica-core/src/main/java/etomica/tests/TestHSMD3D.java
+++ b/etomica-core/src/main/java/etomica/tests/TestHSMD3D.java
@@ -90,7 +90,9 @@ public class TestHSMD3D extends Simulation {
 
         MeterPressureHard pMeter = new MeterPressureHard(sim.integrator);
 
+        sim.LOG.info("Starting simulation");
         sim.getController().actionPerformed();
+        sim.LOG.info("Simulation done");
 
         double Z = pMeter.getDataAsScalar()*sim.box.getBoundary().volume()/(sim.box.getMoleculeList().size()*sim.integrator.getTemperature());
         System.out.println("Z="+Z);

--- a/etomica-core/src/main/java/etomica/tests/TestHSMD3D.java
+++ b/etomica-core/src/main/java/etomica/tests/TestHSMD3D.java
@@ -19,6 +19,9 @@ import etomica.space3d.Space3D;
 import etomica.species.SpeciesSpheresMono;
 import etomica.util.ParameterBase;
 import etomica.util.ParseArgs;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * Simple hard-sphere molecular dynamics simulation in 3D.

--- a/etomica-core/src/main/java/etomica/util/logging/SimLogger.java
+++ b/etomica-core/src/main/java/etomica/util/logging/SimLogger.java
@@ -1,0 +1,814 @@
+package etomica.util.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.spi.AbstractLogger;
+import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
+import org.apache.logging.log4j.util.MessageSupplier;
+import org.apache.logging.log4j.util.StackLocatorUtil;
+import org.apache.logging.log4j.util.Supplier;
+
+/**
+ * Extended Logger interface with convenience methods for
+ * the DATA custom log level.
+ * <p>Compatible with Log4j 2.6 or higher.</p>
+ */
+public final class SimLogger extends ExtendedLoggerWrapper {
+    private static final long serialVersionUID = 375257887553316L;
+    private final ExtendedLoggerWrapper logger;
+
+    private static final String FQCN = SimLogger.class.getName();
+    private static final Level DATA = Level.forName("DATA", 350);
+
+    private SimLogger(final Logger logger) {
+        super((AbstractLogger) logger, logger.getName(), logger.getMessageFactory());
+        this.logger = this;
+    }
+
+    /**
+     * Returns a custom Logger with the name of the calling class.
+     * 
+     * @return The custom Logger for the calling class.
+     */
+    public static SimLogger create() {
+        // TODO: make our own class for this
+        final Logger wrapped = LogManager.getLogger(StackLocatorUtil.getCallerClass(2));
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Returns a custom Logger using the fully qualified name of the Class as
+     * the Logger name.
+     * 
+     * @param loggerName The Class whose name should be used as the Logger name.
+     *            If null it will default to the calling class.
+     * @return The custom Logger.
+     */
+    public static SimLogger create(final Class<?> loggerName) {
+        final Logger wrapped = LogManager.getLogger(loggerName);
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Returns a custom Logger using the fully qualified name of the Class as
+     * the Logger name.
+     * 
+     * @param loggerName The Class whose name should be used as the Logger name.
+     *            If null it will default to the calling class.
+     * @param messageFactory The message factory is used only when creating a
+     *            logger, subsequent use does not change the logger but will log
+     *            a warning if mismatched.
+     * @return The custom Logger.
+     */
+    public static SimLogger create(final Class<?> loggerName, final MessageFactory messageFactory) {
+        final Logger wrapped = LogManager.getLogger(loggerName, messageFactory);
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Returns a custom Logger using the fully qualified class name of the value
+     * as the Logger name.
+     * 
+     * @param value The value whose class name should be used as the Logger
+     *            name. If null the name of the calling class will be used as
+     *            the logger name.
+     * @return The custom Logger.
+     */
+    public static SimLogger create(final Object value) {
+        final Logger wrapped = LogManager.getLogger(value);
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Returns a custom Logger using the fully qualified class name of the value
+     * as the Logger name.
+     * 
+     * @param value The value whose class name should be used as the Logger
+     *            name. If null the name of the calling class will be used as
+     *            the logger name.
+     * @param messageFactory The message factory is used only when creating a
+     *            logger, subsequent use does not change the logger but will log
+     *            a warning if mismatched.
+     * @return The custom Logger.
+     */
+    public static SimLogger create(final Object value, final MessageFactory messageFactory) {
+        final Logger wrapped = LogManager.getLogger(value, messageFactory);
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Returns a custom Logger with the specified name.
+     * 
+     * @param name The logger name. If null the name of the calling class will
+     *            be used.
+     * @return The custom Logger.
+     */
+    public static SimLogger create(final String name) {
+        final Logger wrapped = LogManager.getLogger(name);
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Returns a custom Logger with the specified name.
+     * 
+     * @param name The logger name. If null the name of the calling class will
+     *            be used.
+     * @param messageFactory The message factory is used only when creating a
+     *            logger, subsequent use does not change the logger but will log
+     *            a warning if mismatched.
+     * @return The custom Logger.
+     */
+    public static SimLogger create(final String name, final MessageFactory messageFactory) {
+        final Logger wrapped = LogManager.getLogger(name, messageFactory);
+        return new SimLogger(wrapped);
+    }
+
+    /**
+     * Logs a message with the specific Marker at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param msg the message string to be logged
+     */
+    public void data(final Marker marker, final Message msg) {
+        logger.logIfEnabled(FQCN, DATA, marker, msg, (Throwable) null);
+    }
+
+    /**
+     * Logs a message with the specific Marker at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param msg the message string to be logged
+     * @param t A Throwable or null.
+     */
+    public void data(final Marker marker, final Message msg, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, marker, msg, t);
+    }
+
+    /**
+     * Logs a message object with the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message object to log.
+     */
+    public void data(final Marker marker, final Object message) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, (Throwable) null);
+    }
+
+    /**
+     * Logs a message CharSequence with the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final CharSequence message) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, (Throwable) null);
+    }
+
+    /**
+     * Logs a message at the {@code DATA} level including the stack trace of
+     * the {@link Throwable} {@code t} passed as parameter.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log.
+     * @param t the exception to log, including its stack trace.
+     */
+    public void data(final Marker marker, final Object message, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, t);
+    }
+
+    /**
+     * Logs a message at the {@code DATA} level including the stack trace of
+     * the {@link Throwable} {@code t} passed as parameter.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the CharSequence to log.
+     * @param t the exception to log, including its stack trace.
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final CharSequence message, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, t);
+    }
+
+    /**
+     * Logs a message object with the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message object to log.
+     */
+    public void data(final Marker marker, final String message) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, (Throwable) null);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params parameters to the message.
+     * @see #getMessageFactory()
+     */
+    public void data(final Marker marker, final String message, final Object... params) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, params);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3, p4);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6,
+            final Object p7) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @param p8 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6,
+            final Object p7, final Object p8) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @param p8 parameter to the message.
+     * @param p9 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6,
+            final Object p7, final Object p8, final Object p9) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    /**
+     * Logs a message at the {@code DATA} level including the stack trace of
+     * the {@link Throwable} {@code t} passed as parameter.
+     * 
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log.
+     * @param t the exception to log, including its stack trace.
+     */
+    public void data(final Marker marker, final String message, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, t);
+    }
+
+    /**
+     * Logs the specified Message at the {@code DATA} level.
+     * 
+     * @param msg the message string to be logged
+     */
+    public void data(final Message msg) {
+        logger.logIfEnabled(FQCN, DATA, null, msg, (Throwable) null);
+    }
+
+    /**
+     * Logs the specified Message at the {@code DATA} level.
+     * 
+     * @param msg the message string to be logged
+     * @param t A Throwable or null.
+     */
+    public void data(final Message msg, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, null, msg, t);
+    }
+
+    /**
+     * Logs a message object with the {@code DATA} level.
+     * 
+     * @param message the message object to log.
+     */
+    public void data(final Object message) {
+        logger.logIfEnabled(FQCN, DATA, null, message, (Throwable) null);
+    }
+
+    /**
+     * Logs a message at the {@code DATA} level including the stack trace of
+     * the {@link Throwable} {@code t} passed as parameter.
+     * 
+     * @param message the message to log.
+     * @param t the exception to log, including its stack trace.
+     */
+    public void data(final Object message, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, null, message, t);
+    }
+
+    /**
+     * Logs a message CharSequence with the {@code DATA} level.
+     * 
+     * @param message the message CharSequence to log.
+     * @since Log4j-2.6
+     */
+    public void data(final CharSequence message) {
+        logger.logIfEnabled(FQCN, DATA, null, message, (Throwable) null);
+    }
+
+    /**
+     * Logs a CharSequence at the {@code DATA} level including the stack trace of
+     * the {@link Throwable} {@code t} passed as parameter.
+     * 
+     * @param message the CharSequence to log.
+     * @param t the exception to log, including its stack trace.
+     * @since Log4j-2.6
+     */
+    public void data(final CharSequence message, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, null, message, t);
+    }
+
+    /**
+     * Logs a message object with the {@code DATA} level.
+     * 
+     * @param message the message object to log.
+     */
+    public void data(final String message) {
+        logger.logIfEnabled(FQCN, DATA, null, message, (Throwable) null);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param params parameters to the message.
+     * @see #getMessageFactory()
+     */
+    public void data(final String message, final Object... params) {
+        logger.logIfEnabled(FQCN, DATA, null, message, params);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3, p4);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6,
+            final Object p7) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @param p8 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6,
+            final Object p7, final Object p8) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    /**
+     * Logs a message with parameters at the {@code DATA} level.
+     * 
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @param p8 parameter to the message.
+     * @param p9 parameter to the message.
+     * @see #getMessageFactory()
+     * @since Log4j-2.6
+     */
+    public void data(final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3, final Object p4, final Object p5, final Object p6,
+            final Object p7, final Object p8, final Object p9) {
+        logger.logIfEnabled(FQCN, DATA, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    /**
+     * Logs a message at the {@code DATA} level including the stack trace of
+     * the {@link Throwable} {@code t} passed as parameter.
+     * 
+     * @param message the message to log.
+     * @param t the exception to log, including its stack trace.
+     */
+    public void data(final String message, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, null, message, t);
+    }
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@code DATA}level.
+     *
+     * @param msgSupplier A function, which when called, produces the desired log message;
+     *            the format depends on the message factory.
+     * @since Log4j-2.4
+     */
+    public void data(final Supplier<?> msgSupplier) {
+        logger.logIfEnabled(FQCN, DATA, null, msgSupplier, (Throwable) null);
+    }
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@code DATA}
+     * level) including the stack trace of the {@link Throwable} <code>t</code> passed as parameter.
+     *
+     * @param msgSupplier A function, which when called, produces the desired log message;
+     *            the format depends on the message factory.
+     * @param t the exception to log, including its stack trace.
+     * @since Log4j-2.4
+     */
+    public void data(final Supplier<?> msgSupplier, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, null, msgSupplier, t);
+    }
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the
+     * {@code DATA} level with the specified Marker.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSupplier A function, which when called, produces the desired log message;
+     *            the format depends on the message factory.
+     * @since Log4j-2.4
+     */
+    public void data(final Marker marker, final Supplier<?> msgSupplier) {
+        logger.logIfEnabled(FQCN, DATA, marker, msgSupplier, (Throwable) null);
+    }
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the
+     * {@code DATA} level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since Log4j-2.4
+     */
+    public void data(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+        logger.logIfEnabled(FQCN, DATA, marker, message, paramSuppliers);
+    }
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@code DATA}
+     * level) with the specified Marker and including the stack trace of the {@link Throwable}
+     * <code>t</code> passed as parameter.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSupplier A function, which when called, produces the desired log message;
+     *            the format depends on the message factory.
+     * @param t A Throwable or null.
+     * @since Log4j-2.4
+     */
+    public void data(final Marker marker, final Supplier<?> msgSupplier, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, marker, msgSupplier, t);
+    }
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is
+     * the {@code DATA} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since Log4j-2.4
+     */
+    public void data(final String message, final Supplier<?>... paramSuppliers) {
+        logger.logIfEnabled(FQCN, DATA, null, message, paramSuppliers);
+    }
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the
+     * {@code DATA} level with the specified Marker. The {@code MessageSupplier} may or may
+     * not use the {@link MessageFactory} to construct the {@code Message}.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSupplier A function, which when called, produces the desired log message.
+     * @since Log4j-2.4
+     */
+    public void data(final Marker marker, final MessageSupplier msgSupplier) {
+        logger.logIfEnabled(FQCN, DATA, marker, msgSupplier, (Throwable) null);
+    }
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@code DATA}
+     * level) with the specified Marker and including the stack trace of the {@link Throwable}
+     * <code>t</code> passed as parameter. The {@code MessageSupplier} may or may not use the
+     * {@link MessageFactory} to construct the {@code Message}.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSupplier A function, which when called, produces the desired log message.
+     * @param t A Throwable or null.
+     * @since Log4j-2.4
+     */
+    public void data(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, marker, msgSupplier, t);
+    }
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the
+     * {@code DATA} level. The {@code MessageSupplier} may or may not use the
+     * {@link MessageFactory} to construct the {@code Message}.
+     *
+     * @param msgSupplier A function, which when called, produces the desired log message.
+     * @since Log4j-2.4
+     */
+    public void data(final MessageSupplier msgSupplier) {
+        logger.logIfEnabled(FQCN, DATA, null, msgSupplier, (Throwable) null);
+    }
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@code DATA}
+     * level) including the stack trace of the {@link Throwable} <code>t</code> passed as parameter.
+     * The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * {@code Message}.
+     *
+     * @param msgSupplier A function, which when called, produces the desired log message.
+     * @param t the exception to log, including its stack trace.
+     * @since Log4j-2.4
+     */
+    public void data(final MessageSupplier msgSupplier, final Throwable t) {
+        logger.logIfEnabled(FQCN, DATA, null, msgSupplier, t);
+    }
+}
+

--- a/etomica-core/src/main/resources/log4j2.xml
+++ b/etomica-core/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %highlight{%-5level} %logger{36} - %msg%n%throwable"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="trace">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/etomica-core/src/main/resources/log4j2.xml
+++ b/etomica-core/src/main/resources/log4j2.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
+    <CustomLevels>
+        <CustomLevel name="DATA" intLevel="350"/>
+    </CustomLevels>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %highlight{%-5level} %logger{36} - %msg%n%throwable"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %highlight{%-5level}{DATA=bright, INFO=blue, DEBUG=magenta, TRACE=cyan} %logger{36} - %msg%n%throwable"/>
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
Start using [log4j2](https://logging.apache.org/log4j/2.x/) for logging simulation events and data. Benefits include:

* Configurable log levels, letting the user decide how much information they want to see. The Debug class does this somewhat, but it's better suited for enabling "extra safety checks". It's also nice to have more than 2 levels.

* Complex data routing. E.g. the user could print simulation progress to the (pesky un-pinned) console while data is sent to a uniquely named file.

I chose log4j2 for now instead of the more common slf4j as log4j2 has:

* better documentation and customization options

* possibly better performance, in particular its logging generally does not produce any garbage