### PR TITLE
Species manager

### DIFF
--- a/etomica-core/src/main/java/etomica/nbr/cell/NeighborCellManagerFasterer.java
+++ b/etomica-core/src/main/java/etomica/nbr/cell/NeighborCellManagerFasterer.java
@@ -14,6 +14,7 @@ import etomica.potential.compute.NeighborIterator;
 import etomica.potential.compute.NeighborManager;
 import etomica.simulation.Simulation;
 import etomica.space.Vector;
+import etomica.species.SpeciesManager;
 
 import java.util.Arrays;
 import java.util.stream.IntStream;
@@ -36,14 +37,14 @@ public class NeighborCellManagerFasterer implements NeighborManager {
     protected int[] atomCell;
     public int[] allCellOffsets;
 
-    public NeighborCellManagerFasterer(Simulation sim, Box box, int cellRange, BondingInfo bondingInfo) {
+    public NeighborCellManagerFasterer(SpeciesManager sm, Box box, int cellRange, BondingInfo bondingInfo) {
         this.box = box;
         this.cellRange = cellRange;
         boxHalf = box.getSpace().makeVector();
         numCells = new int[3];
         jump = new int[3];
         cellNextAtom = atomCell = cellOffsets = wrapMap = cellLastAtom = new int[0];
-        this.isPureAtoms = sim.getSpeciesList().stream().allMatch(s -> s.getLeafAtomCount() == 1);
+        this.isPureAtoms = sm.isPureAtoms();
         this.bondingInfo = bondingInfo;
     }
 

--- a/etomica-core/src/main/java/etomica/nbr/cell/PotentialMasterCellFasterer.java
+++ b/etomica-core/src/main/java/etomica/nbr/cell/PotentialMasterCellFasterer.java
@@ -12,15 +12,16 @@ import etomica.potential.Potential2Soft;
 import etomica.potential.PotentialMasterFasterer;
 import etomica.simulation.Simulation;
 import etomica.space.Vector;
+import etomica.species.SpeciesManager;
 
 public class PotentialMasterCellFasterer extends PotentialMasterFasterer {
 
     protected final NeighborCellManagerFasterer cellManager;
     protected int cellRange;
 
-    public PotentialMasterCellFasterer(Simulation sim, Box box, int cellRange, BondingInfo bondingInfo) {
-        super(sim, box, bondingInfo);
-        cellManager = new NeighborCellManagerFasterer(sim, box, cellRange, bondingInfo);
+    public PotentialMasterCellFasterer(SpeciesManager sm, Box box, int cellRange, BondingInfo bondingInfo) {
+        super(sm, box, bondingInfo);
+        cellManager = new NeighborCellManagerFasterer(sm, box, cellRange, bondingInfo);
         this.cellRange = cellRange;
     }
 

--- a/etomica-core/src/main/java/etomica/nbr/list/NeighborListManagerFasterer.java
+++ b/etomica-core/src/main/java/etomica/nbr/list/NeighborListManagerFasterer.java
@@ -13,6 +13,7 @@ import etomica.potential.compute.NeighborManager;
 import etomica.simulation.Simulation;
 import etomica.space.Space;
 import etomica.space.Vector;
+import etomica.species.SpeciesManager;
 import etomica.util.Debug;
 
 public class NeighborListManagerFasterer implements NeighborManager {
@@ -35,20 +36,20 @@ public class NeighborListManagerFasterer implements NeighborManager {
     private int maxNab;
     private Vector[] oldAtomPositions;
 
-    public NeighborListManagerFasterer(Simulation sim, Box box, int cellRange, double nbrRange, BondingInfo bondingInfo) {
+    public NeighborListManagerFasterer(SpeciesManager sm, Box box, int cellRange, double nbrRange, BondingInfo bondingInfo) {
         this.box = box;
         this.space = box.getSpace();
         this.bondingInfo = bondingInfo;
-        this.cellManager = new NeighborCellManagerFasterer(sim, box, cellRange, bondingInfo);
+        this.cellManager = new NeighborCellManagerFasterer(sm, box, cellRange, bondingInfo);
         this.setNeighborRange(nbrRange);
-        numAtomTypes = sim.getAtomTypeCount();
+        numAtomTypes = sm.getAtomTypeCount();
         maxR2 = new double[numAtomTypes];
         maxR2Unsafe = new double[numAtomTypes];
         oldAtomPositions = new Vector[0];
         nbrBoxOffsets = new Vector[0][0];
         nbrs = new int[0][0];
         numAtomNbrsUp = new int[0];
-        isPureAtoms = sim.getSpeciesList().stream().allMatch(s -> s.getLeafAtomCount() == 1);
+        isPureAtoms = sm.isPureAtoms();
         this.neighborIterator = new NeighborIteratorList(this, box);
     }
 

--- a/etomica-core/src/main/java/etomica/nbr/list/PotentialMasterListFasterer.java
+++ b/etomica-core/src/main/java/etomica/nbr/list/PotentialMasterListFasterer.java
@@ -14,15 +14,16 @@ import etomica.potential.Potential2Soft;
 import etomica.potential.PotentialMasterFasterer;
 import etomica.simulation.Simulation;
 import etomica.space.Vector;
+import etomica.species.SpeciesManager;
 import etomica.util.Debug;
 
 public class PotentialMasterListFasterer extends PotentialMasterFasterer implements IntegratorListener {
 
     private final NeighborListManagerFasterer nbrManager;
 
-    public PotentialMasterListFasterer(Simulation sim, Box box, int cellRange, double nbrRange, BondingInfo bondingInfo) {
-        super(sim, box, bondingInfo);
-        this.nbrManager = new NeighborListManagerFasterer(sim, box, cellRange, nbrRange, bondingInfo);
+    public PotentialMasterListFasterer(SpeciesManager sm, Box box, int cellRange, double nbrRange, BondingInfo bondingInfo) {
+        super(sm, box, bondingInfo);
+        this.nbrManager = new NeighborListManagerFasterer(sm, box, cellRange, nbrRange, bondingInfo);
         this.nbrManager.setPairPotentials(this.pairPotentials);
     }
 

--- a/etomica-core/src/main/java/etomica/simulation/Simulation.java
+++ b/etomica-core/src/main/java/etomica/simulation/Simulation.java
@@ -5,9 +5,7 @@
 package etomica.simulation;
 
 import etomica.action.controller.Controller;
-import etomica.atom.AtomType;
 import etomica.box.Box;
-import etomica.chem.elements.IElement;
 import etomica.integrator.Integrator;
 import etomica.meta.annotations.IgnoreProperty;
 import etomica.meta.javadoc.KeepSimJavadoc;
@@ -19,7 +17,9 @@ import etomica.util.random.IRandom;
 import etomica.util.random.RandomMersenneTwister;
 import etomica.util.random.RandomNumberGeneratorUnix;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * The main class that organizes the elements of a molecular simulation.
@@ -36,7 +36,7 @@ public class Simulation {
     private final Controller controller;
 
     private final List<Box> boxes;
-    private SpeciesManager speciesManager = null;
+    private SpeciesManager speciesManager;
     private final SpeciesManager.Builder smBuilder;
 
     /**
@@ -45,14 +45,20 @@ public class Simulation {
      * @param space the space used to construct Vectors etc.
      */
     public Simulation(Space space) {
+        this(space, null);
+    }
+
+    public Simulation(Space space, SpeciesManager speciesManager) {
         this.space = space;
         boxes = new ArrayList<>();
         seeds = RandomNumberGeneratorUnix.getRandSeedArray();
         random = new RandomMersenneTwister(seeds);
         eventManager = new SimulationEventManager(this);
         controller = new Controller();
-        this.smBuilder = SpeciesManager.builder();
+        this.speciesManager = speciesManager;
+        this.smBuilder = speciesManager == null ? SpeciesManager.builder() : null;
     }
+
 
     /**
      * @return the seeds that were used for the random number generator at

--- a/etomica-core/src/main/java/etomica/species/SpeciesManager.java
+++ b/etomica-core/src/main/java/etomica/species/SpeciesManager.java
@@ -8,12 +8,14 @@ import java.util.*;
 public final class SpeciesManager {
 
     private final ISpecies[] speciesArray;
+    private final List<ISpecies> speciesList;
     private final int atomTypeCount;
     private final boolean isPureAtoms;
 
     // TODO should it be public? would need to handle setIndex
     private SpeciesManager(ISpecies[] speciesArray) {
         this.speciesArray = speciesArray;
+        this.speciesList = Arrays.asList(speciesArray);
         this.atomTypeCount = Arrays.stream(speciesArray).mapToInt(ISpecies::getUniqueAtomTypeCount).sum();
         this.isPureAtoms = Arrays.stream(speciesArray).allMatch(s -> s.getLeafAtomCount() == 1);
     }
@@ -24,6 +26,10 @@ public final class SpeciesManager {
 
     public ISpecies[] getSpeciesArray() {
         return this.speciesArray;
+    }
+
+    public List<ISpecies> getSpeciesList() {
+        return this.speciesList;
     }
 
     public ISpecies getSpecies(int idx) {

--- a/etomica-core/src/main/java/etomica/species/SpeciesManager.java
+++ b/etomica-core/src/main/java/etomica/species/SpeciesManager.java
@@ -1,0 +1,105 @@
+package etomica.species;
+
+import etomica.atom.AtomType;
+import etomica.chem.elements.IElement;
+
+import java.util.*;
+
+public final class SpeciesManager {
+
+    private final ISpecies[] speciesArray;
+    private final int atomTypeCount;
+    private final boolean isPureAtoms;
+
+    // TODO should it be public? would need to handle setIndex
+    private SpeciesManager(ISpecies[] speciesArray) {
+        this.speciesArray = speciesArray;
+        this.atomTypeCount = Arrays.stream(speciesArray).mapToInt(ISpecies::getUniqueAtomTypeCount).sum();
+        this.isPureAtoms = Arrays.stream(speciesArray).allMatch(s -> s.getLeafAtomCount() == 1);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public ISpecies[] getSpeciesArray() {
+        return this.speciesArray;
+    }
+
+    public ISpecies getSpecies(int idx) {
+        return speciesArray[idx];
+    }
+
+    public int getSpeciesCount() {
+        return this.speciesArray.length;
+    }
+
+    public int getAtomTypeCount() {
+        return this.atomTypeCount;
+    }
+
+    public boolean isPureAtoms() {
+        return this.isPureAtoms;
+    }
+
+    public static class Builder {
+        private final Map<String, IElement> elementSymbols = new HashMap<>();
+        private final List<ISpecies> speciesList = new ArrayList<>();
+        private int atomTypeCount = 0;
+
+        public SpeciesManager build() {
+            return new SpeciesManager(speciesList.toArray(new ISpecies[0]));
+        }
+
+        public Builder addSpecies(ISpecies species) {
+            Objects.requireNonNull(species);
+            if (speciesList.contains(species)) {
+                throw new IllegalArgumentException("Species is already added: " + species);
+            }
+
+            species.setIndex(speciesList.size());
+            speciesList.add(species);
+
+            for (AtomType atomType : species.getUniqueAtomTypes()) {
+                atomType.setIndex(atomTypeCount);
+                atomTypeCount++;
+
+                IElement newElement = atomType.getElement();
+                elementSymbols.merge(newElement.getSymbol(), newElement, (oldElement, newEl) -> {
+                    if (oldElement != newEl) {
+                        throw new IllegalStateException(
+                                "Element symbol " + newEl.getSymbol() + " already exists in this simulation as a different element"
+                        );
+                    }
+                    return newEl;
+                });
+            }
+
+            return this;
+        }
+
+        public Builder addSpecies(ISpecies... species) {
+            Arrays.stream(species).forEach(this::addSpecies);
+            return this;
+        }
+
+        /**
+         * Method to allow generation of unique string to identify Elements in the Simulation.
+         *
+         * @param symbolBase the base string.
+         * @return an Element symbol starting with symbolBase that does not yet
+         * exist in the Simulation.  Return values will be like "base0, base1, base2..."
+         */
+        public String makeUniqueElementSymbol(String symbolBase) {
+            int n = 0;
+            while (elementSymbols.containsKey(symbolBase + n)) {
+                n++;
+            }
+            // reserve this symbol so future calls to makeUniqueElementSymbol won't return it
+            // this will get replaced by the actual Element when it gets added
+            elementSymbols.put(symbolBase + n, null);
+            return symbolBase + n;
+        }
+
+    }
+}

--- a/etomica-core/src/main/java/etomica/tests/TestEAM.java
+++ b/etomica-core/src/main/java/etomica/tests/TestEAM.java
@@ -46,7 +46,7 @@ public class TestEAM extends Simulation {
         addSpecies(species);
 
         box = this.makeBox();
-        NeighborListManagerFasterer nbrs = new NeighborListManagerFasterer(this, box, 2, 7.2, BondingInfo.noBonding());
+        NeighborListManagerFasterer nbrs = new NeighborListManagerFasterer(this.getSpeciesManager(), box, 2, 7.2, BondingInfo.noBonding());
         nbrs.setDoDownNeighbors(true);
         PotentialComputeEAM potentialMaster = new PotentialComputeEAM(this, box, nbrs);
         potentialMaster.doAllTruncationCorrection = false;

--- a/etomica-core/src/main/java/etomica/tests/TestLJMC3D.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMC3D.java
@@ -48,7 +48,7 @@ public class TestLJMC3D extends Simulation {
 
         double sigma = 1.0;
         box = this.makeBox();
-        potentialMaster = new PotentialMasterCellFasterer(this, box, 2, BondingInfo.noBonding());
+        potentialMaster = new PotentialMasterCellFasterer(this.getSpeciesManager(), box, 2, BondingInfo.noBonding());
         integrator = new IntegratorMCFasterer(potentialMaster, random, 1.1, box);
         mcMoveAtom = new MCMoveAtomFasterer(random, potentialMaster, box);
         mcMoveAtom.setStepSize(0.275 * sigma);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMC3DBrute.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMC3DBrute.java
@@ -48,7 +48,7 @@ public class TestLJMC3DBrute extends Simulation {
 
         double sigma = 1.0;
         box = this.makeBox();
-        potentialMaster = new PotentialMasterFasterer(this, box, BondingInfo.noBonding());
+        potentialMaster = new PotentialMasterFasterer(this.getSpeciesManager(), box, BondingInfo.noBonding());
         integrator = new IntegratorMCFasterer(potentialMaster, random, 1.1, box);
         mcMoveAtom = new MCMoveAtomFasterer(random, potentialMaster, box);
         mcMoveAtom.setStepSize(0.275 * sigma);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMC3DNew.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMC3DNew.java
@@ -49,7 +49,7 @@ public class TestLJMC3DNew extends Simulation {
 
         double sigma = 1.0;
         box = this.makeBox();
-        NeighborCellManagerFasterer cellManager = new NeighborCellManagerFasterer(this, box, 2, BondingInfo.noBonding());
+        NeighborCellManagerFasterer cellManager = new NeighborCellManagerFasterer(this.getSpeciesManager(), box, 2, BondingInfo.noBonding());
         PotentialComputePair compute = new PotentialComputePair(this, box, cellManager);
         integrator = new IntegratorMCFasterer(compute, random, 1.1, box);
         mcMoveAtom = new MCMoveAtomFasterer(random, compute, box);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMCDimerFast.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMCDimerFast.java
@@ -69,7 +69,9 @@ public class TestLJMCDimerFast extends Simulation {
 
         pmBond.setBondingPotential(species, pBond, bonds);
         BondingInfo bi = pmBond.getBondingInfo();
-        PotentialMasterFasterer potentialMaster = cellListing ? new PotentialMasterCellFasterer(this, box, 2, bi) : new PotentialMasterFasterer(this, box, bi);
+        PotentialMasterFasterer potentialMaster = cellListing
+                ? new PotentialMasterCellFasterer(this.getSpeciesManager(), box, 2, bi)
+                : new PotentialMasterFasterer(this.getSpeciesManager(), box, bi);
 
         PotentialCompute compute = PotentialCompute.aggregate(pmBond, potentialMaster);
         integrator = new IntegratorMCFasterer(this, compute, box);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMCDimerRigid.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMCDimerRigid.java
@@ -55,7 +55,9 @@ public class TestLJMCDimerRigid extends Simulation {
 
         double sigma = 1.0;
         box = this.makeBox();
-        PotentialMasterFasterer potentialMaster = cellListing ? new PotentialMasterCellFasterer(this, box, 2, BondingInfo.noBonding()) : new PotentialMasterFasterer(this, box, BondingInfo.noBonding());
+        PotentialMasterFasterer potentialMaster = cellListing
+                ? new PotentialMasterCellFasterer(this.getSpeciesManager(), box, 2, BondingInfo.noBonding())
+                : new PotentialMasterFasterer(this.getSpeciesManager(), box, BondingInfo.noBonding());
 
         integrator = new IntegratorMCFasterer(this, potentialMaster, box);
         integrator.setTemperature(moleculeSize);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMCEwald.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMCEwald.java
@@ -56,7 +56,7 @@ public class TestLJMCEwald extends Simulation {
         PotentialComputeEwaldFourier ewaldFourier = new PotentialComputeEwaldFourier(this, box, BondingInfo.noBonding());
         PotentialComputeEwaldFourier.EwaldParams ewaldParams = ewaldFourier.getOptimalParams(3, 38.5/30.4);
         System.out.println(ewaldParams);
-        PotentialMasterCellFasterer pair = new PotentialMasterCellFasterer(this, box, 2, BondingInfo.noBonding());
+        PotentialMasterCellFasterer pair = new PotentialMasterCellFasterer(this.getSpeciesManager(), box, 2, BondingInfo.noBonding());
         PotentialComputeAggregate aggregate = new PotentialComputeAggregate(pair, ewaldFourier);
 
 

--- a/etomica-core/src/main/java/etomica/tests/TestLJMD3D.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMD3D.java
@@ -44,7 +44,7 @@ public class TestLJMD3D extends Simulation {
         addSpecies(species);
 
         box = this.makeBox();
-        PotentialMasterListFasterer potentialMaster = new PotentialMasterListFasterer(this, box, 2, 4, BondingInfo.noBonding());
+        PotentialMasterListFasterer potentialMaster = new PotentialMasterListFasterer(this.getSpeciesManager(), box, 2, 4, BondingInfo.noBonding());
         double sigma = 1.0;
         integrator = new IntegratorVelocityVerletFasterer(potentialMaster, random, 0.01, 1.1, box);
         box.setNMolecules(species, numAtoms);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMD3DBrute.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMD3DBrute.java
@@ -42,7 +42,7 @@ public class TestLJMD3DBrute extends Simulation {
         addSpecies(species);
 
         box = this.makeBox();
-        PotentialMasterFasterer potentialMaster = new PotentialMasterFasterer(this, box, BondingInfo.noBonding());
+        PotentialMasterFasterer potentialMaster = new PotentialMasterFasterer(this.getSpeciesManager(), box, BondingInfo.noBonding());
         double sigma = 1.0;
         integrator = new IntegratorVelocityVerletFasterer(potentialMaster, random, 0.01, 1.1, box);
         box.setNMolecules(species, numAtoms);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMD3DEwald.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMD3DEwald.java
@@ -56,7 +56,7 @@ public class TestLJMD3DEwald extends Simulation {
         ewaldFourier = new PotentialComputeEwaldFourier(this, box, BondingInfo.noBonding());
         PotentialComputeEwaldFourier.EwaldParams ewaldParams = ewaldFourier.getOptimalParams(3, 38.5/40.4);
         System.out.println(ewaldParams);
-        PotentialMasterListFasterer pair = new PotentialMasterListFasterer(this, box, 2, ewaldParams.rCut + 1, BondingInfo.noBonding());
+        PotentialMasterListFasterer pair = new PotentialMasterListFasterer(this.getSpeciesManager(), box, 2, ewaldParams.rCut + 1, BondingInfo.noBonding());
         PotentialComputeAggregate aggregate = new PotentialComputeAggregate(pair, ewaldFourier);
 //        PotentialComputeAggregate aggregate = new PotentialComputeAggregate(pair);
         integrator = new IntegratorVelocityVerletFasterer(aggregate, random, 0.01, 1.1, box);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMD3DNew.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMD3DNew.java
@@ -47,7 +47,7 @@ public class TestLJMD3DNew extends Simulation {
         addSpecies(species);
 
         box = this.makeBox();
-        NeighborListManagerFasterer nbrManager = new NeighborListManagerFasterer(this, box, 2, 4, BondingInfo.noBonding());
+        NeighborListManagerFasterer nbrManager = new NeighborListManagerFasterer(this.getSpeciesManager(), box, 2, 4, BondingInfo.noBonding());
         PotentialComputePair pairCompute = new PotentialComputePair(this, box, nbrManager);
         double sigma = 1.0;
         integrator = new IntegratorVelocityVerletFasterer(pairCompute, random, 0.01, 1.1, box);

--- a/etomica-core/src/main/java/etomica/tests/TestLJMDDimerFast.java
+++ b/etomica-core/src/main/java/etomica/tests/TestLJMDDimerFast.java
@@ -70,8 +70,8 @@ public class TestLJMDDimerFast extends Simulation {
 
         BondingInfo bi = pmBonding.getBondingInfo();
         PotentialMasterFasterer potentialMaster = nbrListing ?
-                new PotentialMasterListFasterer(this, box, 2, 4, bi)
-                : new PotentialMasterFasterer(this, box, bi);
+                new PotentialMasterListFasterer(this.getSpeciesManager(), box, 2, 4, bi)
+                : new PotentialMasterFasterer(this.getSpeciesManager(), box, bi);
 
         PotentialCompute compute = PotentialCompute.aggregate(potentialMaster, pmBonding);
         integrator = new IntegratorVelocityVerletFasterer(this, compute, box);


### PR DESCRIPTION
(based off of fasterer)

Split out species functionality of Simulation into its own class. Allows better encapsulation and flexibility by passing around immutable species data instead of a Simulation.